### PR TITLE
Add fastest-node auto-select and multi-link / QR import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,12 @@ release.
   - A from-scratch sing-box config generator that emits plain JSON and does not
     depend on sing-box.
   - A pure protocol-fallback state machine (REALITY → Hysteria2 → AmneziaWG) that
-    remembers the last good node per profile across launches.
+    remembers the last good node per profile across launches, with an optional
+    latency ordering that walks nodes fastest-first by measured ping while
+    keeping the anti-DPI fallback.
+  - An "auto-select fastest node" mode for `connect` (`auto` flag): without an
+    explicit node the core pings every candidate and tries the lowest-RTT one
+    first, falling through to the next on a block.
   - An honest leak check: public IP from redundant echo services plus a
     best-effort DNS probe, with a verdict that never reports a false pass.
   - The line-delimited JSON control protocol and the daemon that drives it, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,17 @@ release.
     best-effort DNS probe, with a verdict that never reports a false pass.
   - The line-delimited JSON control protocol and the daemon that drives it, with
     a 6-hour background subscription auto-refresh.
+  - Batch link import (`import_links`): several share links (a pasted block or a
+    `.txt` list) collapse into one profile, skipping blank/comment/duplicate and
+    unparseable lines and reporting how many were imported and skipped.
 - **Windows adapter** that spawns and supervises the sing-box process and reads
   traffic counters from its clash API.
 - **`tenebra-core` sidecar** speaking the control protocol over stdin/stdout.
 - **Desktop app (Tauri 2 — Rust shell + React/TypeScript).**
   - Home, Profiles, Settings and Logs screens.
-  - Import via subscription URL, raw link, `.txt` file, clipboard, or QR code
-    (image file or pasted image).
+  - Import via subscription URL, a single link, several links at once (pasted
+    block or `.txt` list, gathered into one profile), clipboard, or QR code
+    (image file or pasted image), with an imported/skipped summary for batches.
   - Connect/disconnect with automatic or manual node selection, per-node ping,
     and "select fastest".
   - Live traffic graphs, routing and split-tunnel controls, and a leak-check

--- a/core/control/connect.go
+++ b/core/control/connect.go
@@ -47,14 +47,32 @@ func (d *Daemon) handleConnect(ctx context.Context, req Request) Response {
 	// Build the fallback candidates. An explicit node request collapses the walk
 	// to that single node: the user asked for a specific exit, so we honour it and
 	// do not silently wander to another protocol behind their back. Without an
-	// explicit node we hand the machine every server and let DefaultOrder plus the
+	// explicit node we hand the machine every server and let the ordering plus the
 	// per-profile last-good decide the sequence.
 	candidates, err := buildCandidates(p, req.Node)
 	if err != nil {
 		return newError(req.ID, err.Error())
 	}
 
-	m := fallback.New(p.ID, candidates, fallback.DefaultOrder, d.lastGood)
+	// Choose the candidate ordering. The default is protocol preference (the
+	// anti-DPI strategy). When the request asks for auto AND named no explicit
+	// node, we measure each candidate's TCP round-trip and order them fastest
+	// first instead. An explicit node already collapsed the walk to one
+	// candidate, so auto is moot there — honouring the user's exact pick. Either
+	// machine drives the same fallback loop, so the anti-DPI walk (advance to the
+	// next candidate when the lead's connect-probe is blocked) is preserved in
+	// both modes.
+	var m *fallback.Machine
+	if req.Auto && req.Node == "" {
+		// pingCandidates dials only the candidate servers, concurrently and
+		// briefly (see pingOne's pingDialTimeout), so probing never blocks the
+		// connect path for long. Unreachable candidates fall to the back of the
+		// latency order but are still tried.
+		rtt := d.pingCandidates(ctx, p, candidates)
+		m = fallback.NewByLatency(p.ID, candidates, rtt, d.lastGood)
+	} else {
+		m = fallback.New(p.ID, candidates, fallback.DefaultOrder, d.lastGood)
+	}
 
 	// Snapshot routing/tun under lock so the loop builds every per-candidate
 	// config against a consistent view even if set_routing runs meanwhile.
@@ -105,6 +123,36 @@ func (d *Daemon) handleConnect(ctx context.Context, req Request) Response {
 		return newError(req.ID, err.Error())
 	}
 	return resp
+}
+
+// pingCandidates measures the TCP round-trip to each candidate's server and
+// returns a nodeID -> RTT(ms) map holding only the reachable ones; an
+// unreachable or unmeasurable candidate is simply omitted, which NewByLatency
+// reads as "sort last". It restricts the probe to the candidate set (not every
+// server in the profile) so auto only pays for nodes the walk could actually
+// pick, and reuses pingOne so the dial timeout, the injectable dialer/clock, and
+// the best-effort semantics match the ping command exactly.
+func (d *Daemon) pingCandidates(ctx context.Context, p profile.Profile, candidates []fallback.Attempt) map[string]int64 {
+	// Index the candidate IDs so we probe only those servers.
+	want := make(map[string]struct{}, len(candidates))
+	for _, a := range candidates {
+		want[a.NodeID] = struct{}{}
+	}
+	servers := make([]profile.Server, 0, len(candidates))
+	for _, s := range p.Servers {
+		if _, ok := want[s.ID]; ok {
+			servers = append(servers, s)
+		}
+	}
+
+	results := d.pingServers(ctx, servers)
+	rtt := make(map[string]int64, len(results))
+	for _, r := range results {
+		if r.Ok {
+			rtt[r.Node] = r.RTTMs
+		}
+	}
+	return rtt
 }
 
 // handleDisconnect tears the tunnel down to idle and returns the resulting

--- a/core/control/daemon.go
+++ b/core/control/daemon.go
@@ -220,6 +220,8 @@ func (d *Daemon) Handle(ctx context.Context, req Request) Response {
 		return d.handleImportSubscription(ctx, req)
 	case CmdImportLink:
 		return d.handleImportLink(req)
+	case CmdImportLinks:
+		return d.handleImportLinks(req)
 	case CmdRemoveProfile:
 		return d.handleRemoveProfile(req)
 	case CmdRefreshSub:
@@ -344,6 +346,53 @@ func (d *Daemon) handleImportLink(req Request) Response {
 		return newError(req.ID, err.Error())
 	}
 	return d.profileResult(req.ID, p)
+}
+
+// handleImportLinks parses a batch of share links into a single multi-node
+// manual profile. It is the convenience path for pasting several links at once
+// or loading a .txt list: every valid link becomes one server in the same
+// profile, unparseable lines are skipped (and counted) rather than aborting, and
+// duplicates/blanks/comments are dropped by ParseLinks. The reply carries the new
+// profile plus how many links were imported and skipped, so the UI can report
+// "imported N, skipped M".
+func (d *Daemon) handleImportLinks(req Request) Response {
+	if len(req.Links) == 0 {
+		return newError(req.ID, "import_links: missing links")
+	}
+	nodes, skipped := subscription.ParseLinks(req.Links)
+	if len(nodes) == 0 {
+		// Nothing parsed: surface a clear failure (and how many were skipped)
+		// instead of creating an empty profile the user can't connect to.
+		return newError(req.ID, fmt.Sprintf("import_links: no valid links found (%d skipped)", skipped))
+	}
+	name := req.Name
+	if name == "" {
+		name = "Imported links"
+	}
+	p, err := profile.NewProfile(name, profile.SourceManual, "", nodes)
+	if err != nil {
+		return newError(req.ID, err.Error())
+	}
+	if err := d.store.Add(p); err != nil {
+		return newError(req.ID, err.Error())
+	}
+	return d.importLinksResult(req.ID, p, len(nodes), skipped)
+}
+
+// importLinksResult wraps a batch import into the {profile, imported, skipped}
+// response shape. imported is the number of servers added (equal to the profile's
+// server count) and skipped the number of links that failed to parse.
+func (d *Daemon) importLinksResult(id int64, p profile.Profile, imported, skipped int) Response {
+	out := struct {
+		Profile  profile.Profile `json:"profile"`
+		Imported int             `json:"imported"`
+		Skipped  int             `json:"skipped"`
+	}{Profile: p, Imported: imported, Skipped: skipped}
+	resp, err := newResult(id, out)
+	if err != nil {
+		return newError(id, err.Error())
+	}
+	return resp
 }
 
 // handleRemoveProfile deletes a profile, first tearing down the tunnel if it is

--- a/core/control/protocol.go
+++ b/core/control/protocol.go
@@ -75,6 +75,12 @@ type Request struct {
 	Profile string `json:"profile,omitempty"`
 	// Node is the optional explicit node ID for connect.
 	Node string `json:"node,omitempty"`
+	// Auto selects the "fastest node" strategy for connect: when set and no Node
+	// is given, the daemon pings every candidate and walks them by ascending RTT
+	// (fastest first) instead of by protocol preference. It is ignored when Node
+	// is present (an explicit exit wins) and defaults to false, so an omitted
+	// field preserves the original protocol-fallback behaviour exactly.
+	Auto bool `json:"auto,omitempty"`
 	// URL is the subscription URL for import_subscription.
 	URL string `json:"url,omitempty"`
 	// Link is the single share link for import_link.

--- a/core/control/protocol.go
+++ b/core/control/protocol.go
@@ -27,6 +27,7 @@ const (
 	CmdListProfiles       = "list_profiles"
 	CmdImportSubscription = "import_subscription"
 	CmdImportLink         = "import_link"
+	CmdImportLinks        = "import_links"
 	CmdRemoveProfile      = "remove_profile"
 	CmdRefreshSub         = "refresh_subscription"
 	CmdConnect            = "connect"
@@ -85,7 +86,12 @@ type Request struct {
 	URL string `json:"url,omitempty"`
 	// Link is the single share link for import_link.
 	Link string `json:"link,omitempty"`
-	// Name names the profile for import_subscription and import_link.
+	// Links is the batch of share links for import_links. Each element may itself
+	// be a multi-line string (a pasted block) or a single link; the daemon splits
+	// on newlines, drops blanks/comments/duplicates, and counts unparseable lines
+	// as skipped rather than failing the whole import.
+	Links []string `json:"links,omitempty"`
+	// Name names the profile for import_subscription, import_link and import_links.
 	Name string `json:"name,omitempty"`
 	// Mode is the routing mode for set_routing (smart/global/direct) and also the
 	// split mode for set_split (off/exclude/include).

--- a/core/control/protocol_test.go
+++ b/core/control/protocol_test.go
@@ -20,6 +20,11 @@ func TestRequestRoundTrip(t *testing.T) {
 			want: Request{ID: 7, Cmd: CmdConnect, Profile: "p1", Node: "n3"},
 		},
 		{
+			name: "connect auto without node",
+			line: `{"id":8,"cmd":"connect","profile":"p1","auto":true}`,
+			want: Request{ID: 8, Cmd: CmdConnect, Profile: "p1", Auto: true},
+		},
+		{
 			name: "import_subscription",
 			line: `{"id":1,"cmd":"import_subscription","url":"https://sub.example.com/x","name":"Home"}`,
 			want: Request{ID: 1, Cmd: CmdImportSubscription, URL: "https://sub.example.com/x", Name: "Home"},

--- a/core/control/server_test.go
+++ b/core/control/server_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -327,6 +328,88 @@ func TestImportLinkBadLink(t *testing.T) {
 	r := h.await()
 	if r.Ok {
 		t.Error("bad link should fail")
+	}
+}
+
+func TestImportLinksBatchOneProfileManyServers(t *testing.T) {
+	h := newHarness(t)
+	// A pasted block: two good links of different protocols, one comment, one
+	// blank line, and one junk line that must be skipped (not fatal).
+	block := strings.Join([]string{
+		"# my nodes",
+		fakeVLESSLink(),
+		"",
+		"trojan://pw@b.example.com:443#Berlin",
+		"not-a-link",
+	}, "\n")
+
+	h.send(Request{ID: 1, Cmd: CmdImportLinks, Links: []string{block}, Name: "Batch"})
+	r := h.await()
+	var out struct {
+		Profile  profile.Profile `json:"profile"`
+		Imported int             `json:"imported"`
+		Skipped  int             `json:"skipped"`
+	}
+	h.dataInto(r, &out)
+
+	if out.Imported != 2 || out.Skipped != 1 {
+		t.Errorf("imported/skipped = %d/%d, want 2/1", out.Imported, out.Skipped)
+	}
+	if out.Profile.Source != profile.SourceManual {
+		t.Errorf("source = %q, want manual", out.Profile.Source)
+	}
+	if len(out.Profile.Servers) != 2 {
+		t.Fatalf("profile has %d servers, want 2 (one profile, many servers)", len(out.Profile.Servers))
+	}
+	if out.Profile.Name != "Batch" {
+		t.Errorf("name = %q, want Batch", out.Profile.Name)
+	}
+	// The profile must actually be in the store as a single entry.
+	h.send(Request{ID: 2, Cmd: CmdListProfiles})
+	r = h.await()
+	var list struct {
+		Profiles []profile.Profile `json:"profiles"`
+	}
+	h.dataInto(r, &list)
+	if len(list.Profiles) != 1 || list.Profiles[0].ID != out.Profile.ID {
+		t.Errorf("list = %+v, want one profile %s", list.Profiles, out.Profile.ID)
+	}
+}
+
+func TestImportLinksDefaultsNameAndDedupes(t *testing.T) {
+	h := newHarness(t)
+	// Same link twice -> one server. No name given -> a sensible default.
+	h.send(Request{ID: 1, Cmd: CmdImportLinks, Links: []string{fakeVLESSLink(), fakeVLESSLink()}})
+	r := h.await()
+	var out struct {
+		Profile  profile.Profile `json:"profile"`
+		Imported int             `json:"imported"`
+		Skipped  int             `json:"skipped"`
+	}
+	h.dataInto(r, &out)
+	if out.Imported != 1 || out.Skipped != 0 {
+		t.Errorf("imported/skipped = %d/%d, want 1/0 (deduped)", out.Imported, out.Skipped)
+	}
+	if out.Profile.Name == "" {
+		t.Error("expected a default profile name, got empty")
+	}
+}
+
+func TestImportLinksAllInvalidFails(t *testing.T) {
+	h := newHarness(t)
+	h.send(Request{ID: 1, Cmd: CmdImportLinks, Links: []string{"nope", "also-bad"}})
+	r := h.await()
+	if r.Ok {
+		t.Error("a batch with no valid links should fail rather than create an empty profile")
+	}
+}
+
+func TestImportLinksMissingFails(t *testing.T) {
+	h := newHarness(t)
+	h.send(Request{ID: 1, Cmd: CmdImportLinks, Links: nil})
+	r := h.await()
+	if r.Ok {
+		t.Error("missing links should fail")
 	}
 }
 

--- a/core/control/server_test.go
+++ b/core/control/server_test.go
@@ -219,6 +219,40 @@ func (h *harness) importFakeProfile() profile.Profile {
 	return out.Profile
 }
 
+// addProfile builds a profile from nodes and writes it straight to the store,
+// bypassing the import path so a test can stand up a multi-node profile with
+// controlled server addresses (the import path only yields one node per link).
+func (h *harness) addProfile(nodes []model.Node) profile.Profile {
+	h.t.Helper()
+	p, err := profile.NewProfile("Multi", profile.SourceManual, "", nodes)
+	if err != nil {
+		h.t.Fatalf("new profile: %v", err)
+	}
+	if err := h.store.Add(p); err != nil {
+		h.t.Fatalf("add profile: %v", err)
+	}
+	return p
+}
+
+// vlessNode is a minimal renderable VLESS node distinguished only by server
+// address — enough for buildCandidates/serverTags and for a per-host dialer to
+// assign it a latency. Each gets a unique UUID so their stable IDs differ.
+func vlessNode(name, server string) model.Node {
+	return model.Node{
+		Protocol: model.VLESS,
+		Name:     name,
+		Server:   server,
+		Port:     443,
+		UUID:     "11111111-1111-1111-1111-1111111111" + server[len(server)-2:],
+		Flow:     "xtls-rprx-vision",
+		TLS: &model.TLS{
+			Enabled:    true,
+			ServerName: "example.com",
+			Reality:    &model.Reality{PublicKey: "PUBKEY"},
+		},
+	}
+}
+
 func TestStatusInitiallyIdle(t *testing.T) {
 	h := newHarness(t)
 	h.send(Request{ID: 1, Cmd: CmdStatus})
@@ -442,6 +476,159 @@ func TestConnectExplicitNodeNotFound(t *testing.T) {
 	if r.Ok {
 		t.Error("connect with unknown node should fail")
 	}
+}
+
+// perHostDialer returns an injectable dialer whose dial latency depends on the
+// destination host, using the real clock so pingOne measures it. The returned
+// RTTs are coarse (tens of ms) with wide gaps so the resulting latency order is
+// deterministic despite scheduler jitter. An unknown host fails the dial,
+// modelling an unreachable candidate.
+func perHostDialer(byHost map[string]time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, _ /*network*/, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			host = address
+		}
+		d, ok := byHost[host]
+		if !ok {
+			return nil, errors.New("unreachable host")
+		}
+		select {
+		case <-time.After(d):
+			return fakeConn{}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// TestConnectAutoPicksFastestNode verifies the auto strategy: with an injected
+// per-host dialer giving each candidate a distinct RTT, connect (auto, no
+// explicit node) must establish on the fastest one — the first candidate the
+// latency-ordered fallback walk hands out, which the fake runner brings up.
+func TestConnectAutoPicksFastestNode(t *testing.T) {
+	h := newHarness(t)
+	// Three nodes; the second address is the fastest to dial.
+	p := h.addProfile([]model.Node{
+		vlessNode("slow", "203.0.113.10"),
+		vlessNode("fast", "203.0.113.20"),
+		vlessNode("mid", "203.0.113.30"),
+	})
+	h.daemon.dial = perHostDialer(map[string]time.Duration{
+		"203.0.113.10": 60 * time.Millisecond,
+		"203.0.113.20": 3 * time.Millisecond,
+		"203.0.113.30": 25 * time.Millisecond,
+	})
+
+	// The fake runner's probe succeeds on the first candidate, so the connected
+	// node must be the fastest one ("fast").
+	fastID := p.Servers[1].ID
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID, Auto: true})
+	r := h.await()
+	var st State
+	h.dataInto(r, &st)
+	if st.State != StateConnecting {
+		t.Fatalf("connect response state = %q, want connecting", st.State)
+	}
+
+	connected := h.awaitState(StateConnected)
+	if connected["node"] != fastID {
+		t.Errorf("auto connected node = %v, want fastest %s", connected["node"], fastID)
+	}
+	h.send(Request{ID: 3, Cmd: CmdDisconnect})
+	h.await()
+}
+
+// TestConnectAutoFallsBackPastBlockedFastest proves auto keeps the anti-DPI
+// fallback: when the fastest candidate is blocked on its connect-probe, the loop
+// advances to the next fastest rather than failing. failStarts=1 blocks only the
+// first candidate handed out (the fastest), so the connection lands on the
+// second-fastest.
+func TestConnectAutoFallsBackPastBlockedFastest(t *testing.T) {
+	h := newHarness(t)
+	p := h.addProfile([]model.Node{
+		vlessNode("fast", "203.0.113.20"),
+		vlessNode("mid", "203.0.113.30"),
+		vlessNode("slow", "203.0.113.10"),
+	})
+	h.daemon.dial = perHostDialer(map[string]time.Duration{
+		"203.0.113.20": 3 * time.Millisecond,  // fastest, but will be blocked
+		"203.0.113.30": 25 * time.Millisecond, // second fastest, comes up
+		"203.0.113.10": 60 * time.Millisecond,
+	})
+	// Block the first candidate the walk hands out (the fastest); the next one
+	// connects.
+	h.runner.setFailStarts(1)
+
+	midID := p.Servers[1].ID
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID, Auto: true})
+	h.await()
+
+	connected := h.awaitState(StateConnected)
+	if connected["node"] != midID {
+		t.Errorf("auto fallback connected node = %v, want second-fastest %s", connected["node"], midID)
+	}
+	h.send(Request{ID: 3, Cmd: CmdDisconnect})
+	h.await()
+}
+
+// TestConnectAutoIgnoredWithExplicitNode confirms an explicit node wins over
+// auto: the walk collapses to exactly that node even with Auto set, and no
+// candidate pinging reorders anything. We point the explicit node at the
+// slowest-to-dial server; if auto were (wrongly) in effect it would prefer a
+// faster one.
+func TestConnectAutoIgnoredWithExplicitNode(t *testing.T) {
+	h := newHarness(t)
+	p := h.addProfile([]model.Node{
+		vlessNode("fast", "203.0.113.20"),
+		vlessNode("slow", "203.0.113.10"),
+	})
+	h.daemon.dial = perHostDialer(map[string]time.Duration{
+		"203.0.113.20": 3 * time.Millisecond,
+		"203.0.113.10": 60 * time.Millisecond,
+	})
+
+	slowID := p.Servers[1].ID
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID, Node: slowID, Auto: true})
+	h.await()
+
+	connected := h.awaitState(StateConnected)
+	if connected["node"] != slowID {
+		t.Errorf("explicit+auto connected node = %v, want the explicit %s", connected["node"], slowID)
+	}
+	// Exactly one candidate was ever started: the collapse held.
+	h.waitStarts(1)
+	if got := h.runner.starts(); got != 1 {
+		t.Errorf("explicit node started %d candidates, want 1", got)
+	}
+	h.send(Request{ID: 3, Cmd: CmdDisconnect})
+	h.await()
+}
+
+// TestConnectAutoAllUnreachableStillConnects checks that when no candidate
+// answers the cheap TCP ping, auto does not give up: every node is unreachable
+// in the latency sense and sorts to the back in input order, but the walk still
+// tries them and the fake runner brings the first up. (A server can refuse the
+// probe yet complete a real handshake.)
+func TestConnectAutoAllUnreachableStillConnects(t *testing.T) {
+	h := newHarness(t)
+	p := h.addProfile([]model.Node{
+		vlessNode("a", "203.0.113.20"),
+		vlessNode("b", "203.0.113.30"),
+	})
+	// Empty map: every dial fails, so no candidate has a usable RTT.
+	h.daemon.dial = perHostDialer(map[string]time.Duration{})
+
+	firstID := p.Servers[0].ID
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID, Auto: true})
+	h.await()
+
+	connected := h.awaitState(StateConnected)
+	if connected["node"] != firstID {
+		t.Errorf("all-unreachable auto connected node = %v, want input-order first %s", connected["node"], firstID)
+	}
+	h.send(Request{ID: 3, Cmd: CmdDisconnect})
+	h.await()
 }
 
 // TestProcessExitBecomesError simulates sing-box dying during connect; the daemon

--- a/core/fallback/fallback.go
+++ b/core/fallback/fallback.go
@@ -5,6 +5,15 @@
 // then Hysteria2, then AmneziaWG by default), then everything else. The walk is
 // pure — it performs no network I/O — so it is fully unit-testable, and the
 // caller owns the actual dialling and blocking detection.
+//
+// The package offers two orderings, both producing the same kind of Machine so
+// the connect loop is oblivious to which one built it:
+//
+//   - New ranks by protocol preference (the default anti-DPI strategy);
+//   - NewByLatency ranks by measured round-trip time, fastest first, for the
+//     "auto-select fastest node" mode. The anti-DPI fallback is preserved either
+//     way — if the lead candidate's connect-probe is blocked, the loop advances
+//     to the next one in the order.
 package fallback
 
 import (
@@ -31,9 +40,19 @@ type Attempt struct {
 	Node   model.Node
 }
 
+// unreachableRTT is the rank latency-ordering assigns to a candidate with no
+// usable RTT (its probe failed, timed out, or was never measured). It sits past
+// any realistic real-world ping so such candidates sort to the end of the
+// latency walk while still being tried — a server that did not answer a cheap
+// TCP probe may still complete a full handshake, and the anti-DPI walk must not
+// drop it. Using a sentinel rather than omitting these keeps every candidate in
+// the order exactly once, matching the protocol-preference ordering's contract.
+const unreachableRTT = int64(1) << 62
+
 // Machine walks an ordered set of attempts for one profile. It is not safe for
 // concurrent use; a connection manager drives a single profile's reconnect loop
-// from one goroutine. Construct it with New.
+// from one goroutine. Construct it with New (protocol-preference ordering) or
+// NewByLatency (measured-RTT ordering).
 type Machine struct {
 	profileID string
 	lastGood  LastGood
@@ -46,10 +65,18 @@ type Machine struct {
 	// the walk is exhausted.
 	cursor int
 
-	// candidates and pref are kept so the order can be recomputed on Reset and
-	// after Success without the caller re-supplying them.
+	// candidates, pref and latency are kept so the order can be recomputed on
+	// Reset and after Success without the caller re-supplying them.
 	candidates []Attempt
 	pref       []model.Protocol
+
+	// byLatency selects the ordering strategy rebuild applies: false ranks by
+	// protocol preference (pref), true ranks by ascending measured RTT (latency).
+	byLatency bool
+	// latency maps a candidate NodeID to its measured RTT in milliseconds. Only
+	// consulted when byLatency is set. A node absent from the map — or present
+	// with a non-positive value — is treated as unreachable and sorts last.
+	latency map[string]int64
 }
 
 // New builds a Machine for profileID over candidates, preferring protocols in
@@ -76,31 +103,74 @@ func New(profileID string, candidates []Attempt, order []model.Protocol, lastGoo
 	return m
 }
 
-// rebuild recomputes order from candidates, the protocol preference and the
-// current last-good, then rewinds the cursor to the front. The last-good node,
-// if still among the candidates, is moved ahead of everything; the rest follow
-// in protocol-preference order with the original candidate index as a stable
-// tiebreak. Every candidate appears exactly once.
+// NewByLatency builds a Machine for profileID that hands candidates out fastest
+// first, ranked by the measured round-trip times in rtt (keyed by NodeID, in
+// milliseconds). It backs the "auto-select fastest node" mode. A candidate with
+// no entry in rtt, or a non-positive one, counts as unreachable and sorts to the
+// end — it is still tried last (a server that ignored the cheap TCP probe may
+// yet handshake), preserving the anti-DPI fallback. Ties (equal RTT) break
+// toward the last-good node first, then by input order, so a re-measured field
+// of equally-fast servers stays stable across reconnects. The rtt map and the
+// candidates slice are copied, so the caller may reuse both. lastGood may be nil.
+//
+// Why last-good is only a tiebreak here, not a lead: the user asked for the
+// fastest exit, so RTT is authoritative. Letting last-good jump ahead of a
+// measurably faster server would silently override that intent. We still record
+// last-good on Success (see runFallback) and honour it as a lead in the
+// protocol-preference machine, so a later non-auto connect still benefits.
+func NewByLatency(profileID string, candidates []Attempt, rtt map[string]int64, lastGood LastGood) *Machine {
+	cand := make([]Attempt, len(candidates))
+	copy(cand, candidates)
+
+	lat := make(map[string]int64, len(rtt))
+	for k, v := range rtt {
+		lat[k] = v
+	}
+
+	m := &Machine{
+		profileID:  profileID,
+		lastGood:   lastGood,
+		candidates: cand,
+		byLatency:  true,
+		latency:    lat,
+	}
+	m.rebuild()
+	return m
+}
+
+// rebuild recomputes order from candidates, the current last-good, and whichever
+// ordering strategy this machine uses, then rewinds the cursor to the front.
+// Every candidate appears exactly once. It dispatches to the latency or the
+// protocol-preference layout; both share the last-good lookup.
 func (m *Machine) rebuild() {
 	m.cursor = 0
 	m.order = m.order[:0]
 
-	lastID, haveLast := "", false
-	if m.lastGood != nil {
-		lastID, haveLast = m.lastGood.Get(m.profileID)
-	}
-
-	// Index of the last-good candidate, or -1 if it is stale (no longer offered).
+	// Index of the last-good candidate, or -1 if none is set or it is stale (no
+	// longer offered, e.g. removed by a subscription refresh).
 	lastIdx := -1
-	if haveLast {
-		for i := range m.candidates {
-			if m.candidates[i].NodeID == lastID {
-				lastIdx = i
-				break
+	if m.lastGood != nil {
+		if lastID, ok := m.lastGood.Get(m.profileID); ok {
+			for i := range m.candidates {
+				if m.candidates[i].NodeID == lastID {
+					lastIdx = i
+					break
+				}
 			}
 		}
 	}
 
+	if m.byLatency {
+		m.rebuildByLatency(lastIdx)
+		return
+	}
+	m.rebuildByPreference(lastIdx)
+}
+
+// rebuildByPreference lays out order by protocol preference. The last-good node,
+// if still among the candidates, leads everything; the rest follow in
+// preference order with the original candidate index as a stable tiebreak.
+func (m *Machine) rebuildByPreference(lastIdx int) {
 	// rank maps a protocol to its position in the preference list; protocols not
 	// listed rank after all listed ones so they are still tried, just last.
 	rank := func(p model.Protocol) int {
@@ -132,6 +202,48 @@ func (m *Machine) rebuild() {
 		m.order = append(m.order, m.candidates[lastIdx])
 	}
 	for _, i := range rest {
+		m.order = append(m.order, m.candidates[i])
+	}
+}
+
+// rebuildByLatency lays out order fastest first. Unlike the preference layout,
+// last-good does NOT lead — RTT is authoritative for "fastest node" (see
+// NewByLatency) — but it does win an exact-RTT tie, so a field of equally-fast
+// servers stays stable across reconnects. Unreachable candidates (no usable RTT)
+// fold to a sentinel rank and trail, in input order, still tried last.
+func (m *Machine) rebuildByLatency(lastIdx int) {
+	// rtt returns the candidate's measured round-trip, or the unreachable
+	// sentinel when it is missing or non-positive (a failed/absent probe). A
+	// zero RTT is not a real "instant" exit, so it is treated as unreachable too.
+	rtt := func(i int) int64 {
+		if ms, ok := m.latency[m.candidates[i].NodeID]; ok && ms > 0 {
+			return ms
+		}
+		return unreachableRTT
+	}
+
+	idx := make([]int, len(m.candidates))
+	for i := range m.candidates {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		ia, ib := idx[a], idx[b]
+		ra, rb := rtt(ia), rtt(ib)
+		if ra != rb {
+			return ra < rb // lower RTT first
+		}
+		// Equal RTT: the last-good node breaks the tie so reconnects don't churn
+		// between equally-fast servers; otherwise keep the input order.
+		if ia == lastIdx {
+			return true
+		}
+		if ib == lastIdx {
+			return false
+		}
+		return ia < ib
+	})
+
+	for _, i := range idx {
 		m.order = append(m.order, m.candidates[i])
 	}
 }

--- a/core/fallback/fallback_test.go
+++ b/core/fallback/fallback_test.go
@@ -250,3 +250,160 @@ func TestCandidatesCopied(t *testing.T) {
 	cands[0] = node("mutated", model.Trojan)
 	eq(t, drain(m), []string{"re", "hy"})
 }
+
+// --- latency ordering (NewByLatency) ----------------------------------------
+
+func TestByLatencyOrdersAscending(t *testing.T) {
+	// Candidates are out of RTT order; the walk must hand them out fastest first
+	// regardless of protocol preference (the slowest here is the VLESS node that
+	// protocol-ordering would have led with).
+	cands := []Attempt{
+		node("re", model.VLESS),     // 180ms
+		node("hy", model.Hysteria2), // 40ms
+		node("wg", model.AmneziaWG), // 90ms
+	}
+	rtt := map[string]int64{"re": 180, "hy": 40, "wg": 90}
+	m := NewByLatency("p1", cands, rtt, nil)
+	eq(t, drain(m), []string{"hy", "wg", "re"})
+}
+
+func TestByLatencyUnreachableSortLast(t *testing.T) {
+	// A node missing from the map and one with a non-positive RTT are both
+	// unreachable: they trail the reachable nodes, in input order, but are still
+	// handed out (anti-DPI must not drop a server that ignored the TCP probe).
+	cands := []Attempt{
+		node("missing", model.VLESS),  // no entry -> unreachable
+		node("fast", model.Hysteria2), // 30ms
+		node("zero", model.Trojan),    // 0ms -> unreachable
+		node("mid", model.AmneziaWG),  // 120ms
+	}
+	rtt := map[string]int64{"fast": 30, "mid": 120, "zero": 0}
+	m := NewByLatency("p1", cands, rtt, nil)
+	// Reachable first by RTT (fast, mid), then unreachable in input order
+	// (missing before zero).
+	eq(t, drain(m), []string{"fast", "mid", "missing", "zero"})
+}
+
+func TestByLatencyAllUnreachableKeepsInputOrder(t *testing.T) {
+	// With no usable RTT for anyone, every candidate is equally (un)ranked, so
+	// the stable sort preserves input order — and all are still tried.
+	cands := []Attempt{
+		node("a", model.VLESS),
+		node("b", model.Hysteria2),
+		node("c", model.AmneziaWG),
+	}
+	m := NewByLatency("p1", cands, map[string]int64{}, nil)
+	eq(t, drain(m), []string{"a", "b", "c"})
+}
+
+func TestByLatencyEqualRTTStableByInput(t *testing.T) {
+	// Equal RTTs with no last-good fall back to input order.
+	cands := []Attempt{
+		node("x", model.VLESS),
+		node("y", model.Hysteria2),
+		node("z", model.AmneziaWG),
+	}
+	rtt := map[string]int64{"x": 50, "y": 50, "z": 50}
+	m := NewByLatency("p1", cands, rtt, nil)
+	eq(t, drain(m), []string{"x", "y", "z"})
+}
+
+func TestByLatencyLastGoodBreaksTieOnly(t *testing.T) {
+	// last-good "y" shares the lowest RTT with "x": it must win the tie and lead.
+	// But it must NOT jump ahead of a strictly faster node — RTT stays primary.
+	lg := NewMemLastGood()
+	lg.Set("p1", "y")
+	cands := []Attempt{
+		node("x", model.VLESS),        // 50ms
+		node("y", model.Hysteria2),    // 50ms (last-good, ties with x)
+		node("fast", model.AmneziaWG), // 20ms (strictly faster)
+	}
+	rtt := map[string]int64{"x": 50, "y": 50, "fast": 20}
+	m := NewByLatency("p1", cands, rtt, lg)
+	// fast leads on pure RTT; among the 50ms pair, last-good y precedes x.
+	eq(t, drain(m), []string{"fast", "y", "x"})
+}
+
+func TestByLatencyLastGoodDoesNotOverrideFaster(t *testing.T) {
+	// last-good is the SLOWEST node. Under "fastest" it must stay last — proving
+	// last-good never overrides a measurably faster server (the design invariant).
+	lg := NewMemLastGood()
+	lg.Set("p1", "slow")
+	cands := []Attempt{
+		node("slow", model.VLESS),     // 300ms (last-good)
+		node("mid", model.Hysteria2),  // 90ms
+		node("fast", model.AmneziaWG), // 30ms
+	}
+	rtt := map[string]int64{"slow": 300, "mid": 90, "fast": 30}
+	m := NewByLatency("p1", cands, rtt, lg)
+	eq(t, drain(m), []string{"fast", "mid", "slow"})
+}
+
+func TestByLatencyStaleLastGoodIgnored(t *testing.T) {
+	// last-good points at a node no longer offered; it simply has no effect, and
+	// pure RTT order stands.
+	lg := NewMemLastGood()
+	lg.Set("p1", "gone")
+	cands := []Attempt{
+		node("a", model.VLESS),     // 70ms
+		node("b", model.Hysteria2), // 20ms
+	}
+	rtt := map[string]int64{"a": 70, "b": 20}
+	m := NewByLatency("p1", cands, rtt, lg)
+	eq(t, drain(m), []string{"b", "a"})
+}
+
+func TestByLatencyRecordsLastGoodOnSuccess(t *testing.T) {
+	// Even in latency mode, a successful attempt is recorded as last-good so a
+	// later non-auto (protocol-preference) connect can lead with it. Success also
+	// rewinds; the rewound order is still by RTT (last-good only breaks ties).
+	lg := NewMemLastGood()
+	cands := []Attempt{
+		node("fast", model.VLESS),     // 25ms
+		node("mid", model.Hysteria2),  // 80ms
+		node("slow", model.AmneziaWG), // 150ms
+	}
+	rtt := map[string]int64{"fast": 25, "mid": 80, "slow": 150}
+	m := NewByLatency("p1", cands, rtt, lg)
+
+	// Fastest is blocked; we land on the next.
+	first, _ := m.Next()
+	if first.NodeID != "fast" {
+		t.Fatalf("lead = %q; want fast", first.NodeID)
+	}
+	m.Failure(first)
+	second, _ := m.Next()
+	if second.NodeID != "mid" {
+		t.Fatalf("second = %q; want mid", second.NodeID)
+	}
+	m.Success(second)
+
+	if id, ok := lg.Get("p1"); !ok || id != "mid" {
+		t.Fatalf("last-good = %q,%v; want mid,true", id, ok)
+	}
+	// Rewound order is unchanged by the recorded last-good: still pure RTT,
+	// because "mid" does not tie with anyone.
+	eq(t, drain(m), []string{"fast", "mid", "slow"})
+}
+
+func TestByLatencyRTTMapCopied(t *testing.T) {
+	// Mutating the caller's rtt map after construction must not change the walk.
+	cands := []Attempt{
+		node("a", model.VLESS),
+		node("b", model.Hysteria2),
+	}
+	rtt := map[string]int64{"a": 90, "b": 30}
+	m := NewByLatency("p1", cands, rtt, nil)
+	rtt["a"] = 1 // would make a fastest if the map were aliased
+	eq(t, drain(m), []string{"b", "a"})
+}
+
+func TestByLatencyEmptyCandidates(t *testing.T) {
+	m := NewByLatency("p1", nil, nil, NewMemLastGood())
+	if !m.Exhausted() {
+		t.Fatal("latency machine with no candidates not exhausted")
+	}
+	if a, ok := m.Next(); ok {
+		t.Fatalf("Next on empty = %q,true; want zero,false", a.NodeID)
+	}
+}

--- a/core/subscription/links.go
+++ b/core/subscription/links.go
@@ -1,0 +1,51 @@
+package subscription
+
+import (
+	"strings"
+
+	"github.com/Divaaaan/tenebra/core/model"
+)
+
+// ParseLinks parses many raw share links into nodes, the way a user pastes a
+// block of links or hands over a .txt list. It is the batch sibling of ParseLink
+// and deliberately reuses it per line so the per-protocol logic lives in exactly
+// one place.
+//
+// Each entry is split on newlines first (so a single multi-line string and a
+// pre-split slice behave identically), then for every line:
+//
+//   - surrounding whitespace is trimmed;
+//   - blank lines and comments (a line starting with '#' or '//') are ignored —
+//     they are neither parsed nor counted as skipped, matching how
+//     ParseSubscription treats a link-list body;
+//   - an exact-duplicate link (same trimmed text) is collapsed to one node, so
+//     pasting the same server twice doesn't create two entries;
+//   - a line that fails to parse increments skipped instead of aborting, so one
+//     bad line never costs the user the good ones.
+//
+// skipped counts only lines that looked like a link but didn't parse, never the
+// ignored blanks/comments/duplicates. Order is preserved (first occurrence wins
+// for duplicates), which keeps the resulting profile's server list stable and
+// predictable.
+func ParseLinks(raws []string) (nodes []model.Node, skipped int) {
+	seen := make(map[string]struct{})
+	for _, raw := range raws {
+		for _, line := range strings.Split(raw, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") {
+				continue
+			}
+			if _, dup := seen[line]; dup {
+				continue
+			}
+			seen[line] = struct{}{}
+			node, err := ParseLink(line)
+			if err != nil {
+				skipped++
+				continue
+			}
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes, skipped
+}

--- a/core/subscription/links_test.go
+++ b/core/subscription/links_test.go
@@ -1,0 +1,88 @@
+package subscription
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseLinksMixedValidInvalidBlank(t *testing.T) {
+	// One multi-line block holding good links, blanks, comments and junk. The
+	// good ones must parse in order; the two link-shaped junk lines count as
+	// skipped; blanks and comments count as neither.
+	block := strings.Join([]string{
+		"# my servers",
+		"vless://abc@example.com:443?security=tls#a",
+		"",
+		"// inline note",
+		"this-is-not-a-link", // no scheme -> skipped
+		"vmess://%%%bad",      // bad base64 -> skipped
+		"trojan://pw@example.com:443#t",
+		"   ", // whitespace-only -> ignored
+	}, "\n")
+
+	nodes, skipped := ParseLinks([]string{block})
+	if len(nodes) != 2 {
+		t.Fatalf("len(nodes) = %d, want 2", len(nodes))
+	}
+	if skipped != 2 {
+		t.Errorf("skipped = %d, want 2", skipped)
+	}
+	if nodes[0].Name != "a" || nodes[1].Name != "t" {
+		t.Errorf("node names = %q, %q; want a, t", nodes[0].Name, nodes[1].Name)
+	}
+}
+
+func TestParseLinksDeduplicates(t *testing.T) {
+	// The same link three times (across slice entries and within a block)
+	// collapses to a single node; order follows first occurrence.
+	a := "vless://abc@example.com:443?security=tls#a"
+	b := "trojan://pw@example.com:443#b"
+	nodes, skipped := ParseLinks([]string{
+		a,
+		a + "\n" + b,
+		a,
+	})
+	if skipped != 0 {
+		t.Errorf("skipped = %d, want 0", skipped)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("len(nodes) = %d, want 2 (deduped)", len(nodes))
+	}
+	if nodes[0].Name != "a" || nodes[1].Name != "b" {
+		t.Errorf("node names = %q, %q; want a, b", nodes[0].Name, nodes[1].Name)
+	}
+}
+
+func TestParseLinksAllInvalid(t *testing.T) {
+	nodes, skipped := ParseLinks([]string{"nope", "also-bad", "vmess://%%%"})
+	if len(nodes) != 0 {
+		t.Errorf("len(nodes) = %d, want 0", len(nodes))
+	}
+	if skipped != 3 {
+		t.Errorf("skipped = %d, want 3", skipped)
+	}
+}
+
+func TestParseLinksEmptyAndCommentsOnly(t *testing.T) {
+	// Nothing link-shaped at all: no nodes and, crucially, nothing skipped —
+	// blanks and comments are not failures.
+	nodes, skipped := ParseLinks([]string{"", "  \n # comment \n // note", "\n\n"})
+	if len(nodes) != 0 {
+		t.Errorf("len(nodes) = %d, want 0", len(nodes))
+	}
+	if skipped != 0 {
+		t.Errorf("skipped = %d, want 0", skipped)
+	}
+}
+
+func TestParseLinksTrimsSurroundingWhitespace(t *testing.T) {
+	// Leading/trailing whitespace (incl. a stray \r from CRLF input) must not
+	// stop a link from parsing.
+	nodes, skipped := ParseLinks([]string{"  \tvless://abc@example.com:443?security=tls#a\r"})
+	if skipped != 0 {
+		t.Errorf("skipped = %d, want 0", skipped)
+	}
+	if len(nodes) != 1 || nodes[0].Name != "a" {
+		t.Fatalf("got %d nodes, want 1 named 'a'", len(nodes))
+	}
+}

--- a/docs/control-protocol.md
+++ b/docs/control-protocol.md
@@ -24,7 +24,7 @@ Three message kinds flow over the link:
 | `import_link`          | `link`, `name?`                    | `{ profile: Profile }`      |
 | `remove_profile`       | `profile`                          | —                           |
 | `refresh_subscription` | `profile`                          | `{ profile: Profile }`      |
-| `connect`              | `profile`, `node?`                 | `State`                     |
+| `connect`              | `profile`, `node?`, `auto?`        | `State`                     |
 | `disconnect`           | —                                  | `State`                     |
 | `ping`                 | `profile`                          | `{ results: PingResult[] }` |
 | `set_routing`          | `mode` (`smart`/`global`/`direct`) | `State`                     |
@@ -37,7 +37,30 @@ response: {"id":7,"ok":true,"data":{"state":"connecting","node":"n3"}}
 error:    {"id":7,"ok":false,"error":"profile not found"}
 ```
 
-If `node` is omitted from `connect`, the core picks the lowest-ping node.
+### Node selection (`connect`)
+
+`connect` chooses an exit one of three ways:
+
+- with an explicit `node`, the core uses **exactly** that server and does not
+  wander to another (an explicit exit is honoured as-is). `auto` is ignored.
+- without a `node` and with `auto:true`, the core **pings every candidate** (a
+  short, parallel TCP dial) and walks them **fastest first** by measured
+  round-trip; candidates that fail the probe sort last but are still tried.
+- without a `node` and with `auto` omitted/`false` (the default), the core walks
+  candidates by **protocol preference** (REALITY-flavoured VLESS → Hysteria2 →
+  AmneziaWG), leading with the profile's last-good node.
+
+The **anti-DPI fallback is preserved in every mode**: if the leading candidate's
+connectivity probe is blocked, the core advances to the next candidate in the
+chosen order rather than failing. In `auto` mode, RTT is authoritative — a faster
+server always leads — while the per-profile last-good node only breaks an exact
+RTT tie and is still recorded on a successful connect for the protocol-fallback
+path.
+
+```
+request:  {"id":7,"cmd":"connect","profile":"p1","auto":true}
+response: {"id":7,"ok":true,"data":{"state":"connecting","profile":"p1"}}
+```
 
 `set_routing` and `set_split` only record the choice; like a routing change, a
 new split takes effect on the **next connect** (live retuning would require

--- a/docs/control-protocol.md
+++ b/docs/control-protocol.md
@@ -22,6 +22,7 @@ Three message kinds flow over the link:
 | `list_profiles`        | —                                  | `{ profiles: Profile[] }`   |
 | `import_subscription`  | `url`, `name`                      | `{ profile: Profile }`      |
 | `import_link`          | `link`, `name?`                    | `{ profile: Profile }`      |
+| `import_links`         | `links` (string[]), `name?`        | `{ profile: Profile, imported, skipped }` |
 | `remove_profile`       | `profile`                          | —                           |
 | `refresh_subscription` | `profile`                          | `{ profile: Profile }`      |
 | `connect`              | `profile`, `node?`, `auto?`        | `State`                     |
@@ -60,6 +61,33 @@ path.
 ```
 request:  {"id":7,"cmd":"connect","profile":"p1","auto":true}
 response: {"id":7,"ok":true,"data":{"state":"connecting","profile":"p1"}}
+```
+
+### Batch link import (`import_links`)
+
+`import_links` collects several share links into **one** manual profile holding
+all of them as servers — the convenience path for pasting a block of links or
+loading a `.txt` list. `links` is an array of strings; each element may be a
+single link or a multi-line block (the core splits on newlines), so a UI can pass
+the raw textarea/file body as one entry.
+
+Parsing is forgiving so one bad line never costs the user the good ones:
+
+- surrounding whitespace is trimmed;
+- blank lines and comments (a line starting with `#` or `//`) are ignored — they
+  count as neither imported nor skipped;
+- exact-duplicate links collapse to a single server (first occurrence wins,
+  preserving order);
+- a line that looks like a link but fails to parse is **skipped** (counted), not
+  fatal.
+
+The reply carries the new profile plus `imported` (servers added) and `skipped`
+(links that failed to parse) so the UI can report "imported N, skipped M". A
+batch with **no** parseable links is an error rather than an empty profile.
+
+```
+request:  {"id":7,"cmd":"import_links","links":["vless://…#a\ntrojan://…#b\nbad-line"],"name":"Mine"}
+response: {"id":7,"ok":true,"data":{"profile":{ /* …two servers… */ },"imported":2,"skipped":1}}
 ```
 
 `set_routing` and `set_split` only record the choice; like a routing change, a

--- a/ui-desktop/src-tauri/src/backend/mock.rs
+++ b/ui-desktop/src-tauri/src/backend/mock.rs
@@ -259,7 +259,7 @@ impl Backend for MockBackend {
         Ok(updated)
     }
 
-    fn connect(&self, profile: String, node: Option<String>) -> Result<State, String> {
+    fn connect(&self, profile: String, node: Option<String>, auto: bool) -> Result<State, String> {
         let mut inner = self.shared.inner.lock().unwrap();
         let p = inner
             .profiles
@@ -270,12 +270,15 @@ impl Backend for MockBackend {
         if p.nodes.is_empty() {
             return Err("profile has no nodes".into());
         }
-        // Honour the requested node, else fall back to the first — the protocol
-        // says the core picks the lowest-ping node, which for the mock is just
-        // the head of the list.
+        // Honour an explicit node. Without one, `auto` decides: the fastest node
+        // by the same synthetic ping the `ping` command reports (so the demo's
+        // "auto" actually reflects the latencies the user sees), or just the head
+        // of the list for the default protocol-fallback order. An explicit node
+        // overrides `auto`, mirroring the core.
         let chosen = match node {
             Some(id) if p.nodes.iter().any(|n| n.id == id) => id,
             Some(id) => return Err(format!("node {id} not in profile")),
+            None if auto => fastest_node(&p).unwrap_or_else(|| p.nodes[0].id.clone()),
             None => p.nodes[0].id.clone(),
         };
         let node_name = p
@@ -322,23 +325,7 @@ impl Backend for MockBackend {
             .iter()
             .find(|p| p.id == profile)
             .ok_or("profile not found")?;
-        let mut seed: u64 = 0x2545_f491_4f6c_dd1d ^ (p.nodes.len() as u64);
-        let results = p
-            .nodes
-            .iter()
-            .map(|n| {
-                seed = next_rand(seed);
-                let r = (seed >> 33) % 100;
-                // ~1 in 12 nodes looks unreachable, the rest 20–260 ms.
-                let ok = r % 12 != 0;
-                PingResult {
-                    node: n.id.clone(),
-                    rtt_ms: if ok { 20 + (r as i64 * 24 % 240) } else { 0 },
-                    ok,
-                }
-            })
-            .collect();
-        Ok(results)
+        Ok(synth_ping(p))
     }
 
     fn set_routing(&self, mode: RoutingMode) -> Result<State, String> {
@@ -439,6 +426,38 @@ const GIB: u64 = 1024 * 1024 * 1024;
 fn next_rand(seed: u64) -> u64 {
     seed.wrapping_mul(6_364_136_223_846_793_005)
         .wrapping_add(1_442_695_040_888_963_407)
+}
+
+/// Deterministic synthetic ping for a profile's nodes: ~1 in 12 looks
+/// unreachable, the rest land in 20–260 ms. Factored out so `ping` and the
+/// auto-connect node pick (`fastest_node`) read the same latencies — otherwise
+/// the demo could "auto-select fastest" a node the ping panel shows as slow.
+fn synth_ping(p: &Profile) -> Vec<PingResult> {
+    let mut seed: u64 = 0x2545_f491_4f6c_dd1d ^ (p.nodes.len() as u64);
+    p.nodes
+        .iter()
+        .map(|n| {
+            seed = next_rand(seed);
+            let r = (seed >> 33) % 100;
+            let ok = r % 12 != 0;
+            PingResult {
+                node: n.id.clone(),
+                rtt_ms: if ok { 20 + (r as i64 * 24 % 240) } else { 0 },
+                ok,
+            }
+        })
+        .collect()
+}
+
+/// The id of the reachable node with the lowest synthetic ping, or `None` when
+/// none answered. Mirrors the core's auto strategy for the mock: rank by RTT,
+/// skip the unreachable. Ties resolve to the earlier node (first wins).
+fn fastest_node(p: &Profile) -> Option<String> {
+    synth_ping(p)
+        .into_iter()
+        .filter(|r| r.ok)
+        .min_by_key(|r| r.rtt_ms)
+        .map(|r| r.node)
 }
 
 fn demo_profiles() -> Vec<Profile> {
@@ -859,9 +878,9 @@ mod tests {
     #[test]
     fn connect_transitions_to_connecting() {
         let (b, sink) = backend();
-        let s = b.connect("demo-sub".into(), None).unwrap();
+        let s = b.connect("demo-sub".into(), None, false).unwrap();
         assert_eq!(s.state, ConnectionState::Connecting);
-        // Auto node selection picks the head of the list.
+        // Default (non-auto) node selection picks the head of the list.
         assert_eq!(s.node, Some("demo-nl".into()));
         assert_eq!(s.profile, Some("demo-sub".into()));
         // The synchronous transition was emitted.
@@ -877,23 +896,56 @@ mod tests {
     fn connect_honours_an_explicit_node() {
         let (b, _) = backend();
         let s = b
-            .connect("demo-sub".into(), Some("demo-de".into()))
+            .connect("demo-sub".into(), Some("demo-de".into()), false)
             .unwrap();
         assert_eq!(s.node, Some("demo-de".into()));
         let _ = b.disconnect();
     }
 
     #[test]
-    fn connect_rejects_unknown_node_and_profile() {
+    fn connect_explicit_node_overrides_auto() {
+        // With both an explicit node and auto set, the explicit node wins —
+        // matching the core, where auto is ignored when a node is named.
         let (b, _) = backend();
-        assert!(b.connect("demo-sub".into(), Some("nope".into())).is_err());
-        assert!(b.connect("does-not-exist".into(), None).is_err());
+        let s = b
+            .connect("demo-sub".into(), Some("demo-de".into()), true)
+            .unwrap();
+        assert_eq!(s.node, Some("demo-de".into()));
+        let _ = b.disconnect();
+    }
+
+    #[test]
+    fn connect_auto_picks_the_lowest_ping_node() {
+        // Auto must select the reachable node with the smallest synthetic ping,
+        // exactly what the ping panel would surface for the same profile.
+        let (b, _) = backend();
+        let profiles = b.list_profiles().unwrap();
+        let sub = profiles.iter().find(|p| p.id == "demo-sub").unwrap();
+        let expected = fastest_node(sub).expect("at least one reachable demo node");
+
+        let s = b.connect("demo-sub".into(), None, true).unwrap();
+        assert_eq!(s.node, Some(expected));
+        let _ = b.disconnect();
+    }
+
+    #[test]
+    fn connect_rejects_unknown_node_and_profile() {
+        assert!(b_connect_err(Some("nope".into())));
+        let (b, _) = backend();
+        assert!(b.connect("does-not-exist".into(), None, false).is_err());
+    }
+
+    /// Helper: a connect to demo-sub with the given node that is expected to
+    /// fail, returning whether it did. Keeps the rejection test terse.
+    fn b_connect_err(node: Option<String>) -> bool {
+        let (b, _) = backend();
+        b.connect("demo-sub".into(), node, false).is_err()
     }
 
     #[test]
     fn disconnect_returns_to_idle() {
         let (b, _) = backend();
-        let _ = b.connect("demo-sub".into(), None).unwrap();
+        let _ = b.connect("demo-sub".into(), None, false).unwrap();
         let s = b.disconnect().unwrap();
         assert_eq!(s.state, ConnectionState::Idle);
         assert_eq!(s.node, None);
@@ -953,7 +1005,7 @@ mod tests {
     #[test]
     fn removing_the_active_profile_tears_down_the_tunnel() {
         let (b, sink) = backend();
-        let _ = b.connect("demo-sub".into(), None).unwrap();
+        let _ = b.connect("demo-sub".into(), None, false).unwrap();
         let states_before = sink.state_count();
         b.remove_profile("demo-sub".into()).unwrap();
         // Removing the connected profile emits an extra idle state event.

--- a/ui-desktop/src-tauri/src/backend/mock.rs
+++ b/ui-desktop/src-tauri/src/backend/mock.rs
@@ -9,8 +9,8 @@ use std::thread;
 use std::time::Duration;
 
 use super::{
-    Backend, ConnectionState, DnsResult, DnsStatus, EventSink, ExitMatch, LeakCheck, Node,
-    PingResult, Profile, Protocol, RoutingMode, Source, SplitMode, State, Verdict,
+    Backend, ConnectionState, DnsResult, DnsStatus, EventSink, ExitMatch, ImportLinksResult,
+    LeakCheck, Node, PingResult, Profile, Protocol, RoutingMode, Source, SplitMode, State, Verdict,
 };
 
 /// How long the fake "dial" takes before flipping to connected.
@@ -214,6 +214,54 @@ impl Backend for MockBackend {
             .log("info", &format!("imported link \"{name}\""));
         self.shared.emit_profiles();
         Ok(profile)
+    }
+
+    fn import_links(
+        &self,
+        links: Vec<String>,
+        name: Option<String>,
+    ) -> Result<ImportLinksResult, String> {
+        // Mirror the core's batch parsing well enough for the demo: split each
+        // entry on newlines, trim, drop blanks/comments and duplicates, then count
+        // a line as a server if it looks like a link (has a scheme) or skip it.
+        // The mock can't truly parse a link, so "looks like a link" stands in for
+        // the core's per-protocol parser.
+        let (nodes, skipped) = parse_links_mock(&links);
+        if nodes.is_empty() {
+            return Err(format!("no valid links found ({skipped} skipped)"));
+        }
+        let imported = nodes.len() as u32;
+        let name = name
+            .map(|n| n.trim().to_string())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| "Imported links".to_string());
+        let profile = Profile {
+            id: new_id("man"),
+            name: name.clone(),
+            source: Source::Manual,
+            url: None,
+            nodes,
+            updated_at: now_rfc3339(),
+            expires_at: None,
+            traffic_used: None,
+            traffic_total: None,
+        };
+        self.shared
+            .inner
+            .lock()
+            .unwrap()
+            .profiles
+            .push(profile.clone());
+        self.shared.sink.log(
+            "info",
+            &format!("imported {imported} link(s) into \"{name}\" ({skipped} skipped)"),
+        );
+        self.shared.emit_profiles();
+        Ok(ImportLinksResult {
+            profile,
+            imported,
+            skipped,
+        })
     }
 
     fn remove_profile(&self, profile: String) -> Result<(), String> {
@@ -571,6 +619,50 @@ fn normalize_split_apps(apps: Vec<String>) -> Vec<String> {
     out
 }
 
+/// A line "looks like" a share link if it has a `scheme://` prefix. The mock
+/// uses this as a stand-in for the core's real parser when counting batch
+/// imports, so a junk line is skipped rather than silently turned into a node.
+fn looks_like_link(line: &str) -> bool {
+    match line.split_once("://") {
+        Some((scheme, rest)) => !scheme.is_empty() && !rest.is_empty(),
+        None => false,
+    }
+}
+
+/// Demo-grade batch link parser mirroring the core's `ParseLinks` shape: split on
+/// newlines, trim, drop blanks / `#` / `//` comments and exact duplicates, build a
+/// node per link-shaped line and count the rest as skipped. Returns
+/// `(nodes, skipped)`.
+fn parse_links_mock(links: &[String]) -> (Vec<Node>, u32) {
+    let mut nodes = Vec::new();
+    let mut skipped = 0u32;
+    let mut seen = std::collections::HashSet::new();
+    for raw in links {
+        for line in raw.split('\n') {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with("//") {
+                continue;
+            }
+            if !seen.insert(line.to_string()) {
+                continue; // exact duplicate
+            }
+            if looks_like_link(line) {
+                let protocol = protocol_from_link(line);
+                nodes.push(node_lit(
+                    &new_id("n"),
+                    &format!("{} server", protocol_label(protocol)),
+                    protocol,
+                    "203.0.113.10",
+                    443,
+                ));
+            } else {
+                skipped += 1;
+            }
+        }
+    }
+    (nodes, skipped)
+}
+
 fn protocol_from_link(link: &str) -> Protocol {
     let scheme = link.split("://").next().unwrap_or("").to_ascii_lowercase();
     match scheme.as_str() {
@@ -851,6 +943,47 @@ mod tests {
             .unwrap();
         assert_eq!(p.name, "My SS");
         assert_eq!(p.nodes[0].protocol, Protocol::Shadowsocks);
+    }
+
+    #[test]
+    fn parse_links_mock_counts_and_dedupes() {
+        // A block with two good links, a comment, a blank, a junk line and a
+        // duplicate: two nodes, one skipped, the dup collapsed.
+        let block = "# header\nvless://a@h:443\n\n// note\ngarbage\nvless://a@h:443\nss://b@h:8388";
+        let (nodes, skipped) = parse_links_mock(&[block.to_string()]);
+        assert_eq!(nodes.len(), 2, "two unique link-shaped lines");
+        assert_eq!(skipped, 1, "one junk line skipped");
+    }
+
+    #[test]
+    fn import_links_creates_one_multi_node_profile_and_signals() {
+        let (b, sink) = backend();
+        let before = sink.profiles_count();
+        let res = b
+            .import_links(
+                vec!["vless://a@h:443\ntrojan://b@h:443\nnot-a-link".into()],
+                Some("Batch".into()),
+            )
+            .unwrap();
+        assert_eq!(res.imported, 2);
+        assert_eq!(res.skipped, 1);
+        assert_eq!(res.profile.source, Source::Manual);
+        assert_eq!(res.profile.nodes.len(), 2);
+        assert_eq!(res.profile.name, "Batch");
+        assert_eq!(sink.profiles_count(), before + 1);
+        assert!(b.list_profiles().unwrap().iter().any(|p| p.id == res.profile.id));
+    }
+
+    #[test]
+    fn import_links_defaults_name_and_rejects_all_invalid() {
+        let (b, _) = backend();
+        // No name -> a non-empty default.
+        let res = b.import_links(vec!["vless://a@h:443".into()], None).unwrap();
+        assert!(!res.profile.name.is_empty());
+        // Nothing parseable -> an error, not an empty profile.
+        assert!(b
+            .import_links(vec!["nope".into(), "also-bad".into()], None)
+            .is_err());
     }
 
     #[test]

--- a/ui-desktop/src-tauri/src/backend/mod.rs
+++ b/ui-desktop/src-tauri/src/backend/mod.rs
@@ -114,6 +114,17 @@ pub struct Profile {
     pub traffic_total: Option<u64>,
 }
 
+/// Result of a batch link import (`import_links`): the single profile created
+/// from all the valid links, plus how many links were imported and how many were
+/// skipped because they didn't parse. Mirrors the core's wrapped response so the
+/// UI can report "imported N, skipped M".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportLinksResult {
+    pub profile: Profile,
+    pub imported: u32,
+    pub skipped: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PingResult {
@@ -228,6 +239,16 @@ pub trait Backend: Send + Sync + 'static {
     fn list_profiles(&self) -> Result<Vec<Profile>, String>;
     fn import_subscription(&self, url: String, name: String) -> Result<Profile, String>;
     fn import_link(&self, link: String, name: Option<String>) -> Result<Profile, String>;
+    /// Import several share links at once into a single multi-node profile.
+    /// `links` may hold pasted multi-line blocks or individual links; the core
+    /// splits, de-duplicates, skips comments/blanks, and counts unparseable lines
+    /// in the returned `skipped` rather than failing. An empty result (no valid
+    /// links) is an error.
+    fn import_links(
+        &self,
+        links: Vec<String>,
+        name: Option<String>,
+    ) -> Result<ImportLinksResult, String>;
     fn remove_profile(&self, profile: String) -> Result<(), String>;
     fn refresh_subscription(&self, profile: String) -> Result<Profile, String>;
     /// Start a connection. With an explicit `node` the core uses exactly that

--- a/ui-desktop/src-tauri/src/backend/mod.rs
+++ b/ui-desktop/src-tauri/src/backend/mod.rs
@@ -230,7 +230,11 @@ pub trait Backend: Send + Sync + 'static {
     fn import_link(&self, link: String, name: Option<String>) -> Result<Profile, String>;
     fn remove_profile(&self, profile: String) -> Result<(), String>;
     fn refresh_subscription(&self, profile: String) -> Result<Profile, String>;
-    fn connect(&self, profile: String, node: Option<String>) -> Result<State, String>;
+    /// Start a connection. With an explicit `node` the core uses exactly that
+    /// exit. Without one, `auto` chooses the candidate ordering the core walks:
+    /// `false` keeps the protocol-fallback order, `true` selects the fastest node
+    /// by measured ping. `auto` is ignored when `node` is set.
+    fn connect(&self, profile: String, node: Option<String>, auto: bool) -> Result<State, String>;
     fn disconnect(&self) -> Result<State, String>;
     fn ping(&self, profile: String) -> Result<Vec<PingResult>, String>;
     fn set_routing(&self, mode: RoutingMode) -> Result<State, String>;

--- a/ui-desktop/src-tauri/src/backend/sidecar.rs
+++ b/ui-desktop/src-tauri/src/backend/sidecar.rs
@@ -31,8 +31,8 @@ use serde::de::DeserializeOwned;
 use serde_json::{json, Value};
 
 use super::{
-    Backend, EventSink, LeakCheck, PingResult, Profile, RoutingMode, SplitMode, State, EVENT_LOG,
-    EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
+    Backend, EventSink, ImportLinksResult, LeakCheck, PingResult, Profile, RoutingMode, SplitMode,
+    State, EVENT_LOG, EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
 };
 
 /// How long a request waits for its correlated response before giving up. The
@@ -444,6 +444,23 @@ impl Backend for SidecarBackend {
             ]),
         )?;
         Ok(wrap.profile)
+    }
+
+    fn import_links(
+        &self,
+        links: Vec<String>,
+        name: Option<String>,
+    ) -> Result<ImportLinksResult, String> {
+        // The core returns {profile, imported, skipped} directly (not wrapped in a
+        // `profile` envelope like the single-import paths), so deserialize the
+        // whole data payload into the result.
+        self.inner.request_into(
+            "import_links",
+            obj([
+                ("links", json!(links)),
+                ("name", name.map(Value::from).unwrap_or(Value::Null)),
+            ]),
+        )
     }
 
     fn remove_profile(&self, profile: String) -> Result<(), String> {

--- a/ui-desktop/src-tauri/src/backend/sidecar.rs
+++ b/ui-desktop/src-tauri/src/backend/sidecar.rs
@@ -459,12 +459,17 @@ impl Backend for SidecarBackend {
         Ok(wrap.profile)
     }
 
-    fn connect(&self, profile: String, node: Option<String>) -> Result<State, String> {
+    fn connect(&self, profile: String, node: Option<String>, auto: bool) -> Result<State, String> {
+        // `auto` is sent only when set: omitting it (the common case) keeps the
+        // line minimal and the core defaults a missing field to false, the
+        // original protocol-fallback behaviour. With an explicit node the core
+        // ignores it, so there is no need to special-case that here.
         self.inner.request_into(
             "connect",
             obj([
                 ("profile", json!(profile)),
                 ("node", node.map(Value::from).unwrap_or(Value::Null)),
+                ("auto", if auto { json!(true) } else { Value::Null }),
             ]),
         )
     }

--- a/ui-desktop/src-tauri/src/lib.rs
+++ b/ui-desktop/src-tauri/src/lib.rs
@@ -14,8 +14,8 @@ use serde_json::json;
 use tauri::{AppHandle, Emitter, Manager, State as TauriState, WindowEvent};
 
 use backend::{
-    Backend, ConnectionState, EventSink, LeakCheck, PingResult, Profile, RoutingMode, SplitMode,
-    State, EVENT_LOG, EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
+    Backend, ConnectionState, EventSink, ImportLinksResult, LeakCheck, PingResult, Profile,
+    RoutingMode, SplitMode, State, EVENT_LOG, EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
 };
 
 /// Held in Tauri's managed state and shared by every command handler. The
@@ -176,6 +176,18 @@ async fn import_link(
 }
 
 #[tauri::command]
+async fn import_links(
+    state: TauriState<'_, AppState>,
+    links: Vec<String>,
+    name: Option<String>,
+) -> Result<ImportLinksResult, String> {
+    off_thread(Arc::clone(&state.backend), move |b| {
+        b.import_links(links, name)
+    })
+    .await
+}
+
+#[tauri::command]
 async fn remove_profile(state: TauriState<'_, AppState>, profile: String) -> Result<(), String> {
     off_thread(Arc::clone(&state.backend), move |b| {
         b.remove_profile(profile)
@@ -307,6 +319,7 @@ pub fn run() {
             list_profiles,
             import_subscription,
             import_link,
+            import_links,
             remove_profile,
             refresh_subscription,
             connect,

--- a/ui-desktop/src-tauri/src/lib.rs
+++ b/ui-desktop/src-tauri/src/lib.rs
@@ -199,9 +199,13 @@ async fn connect(
     state: TauriState<'_, AppState>,
     profile: String,
     node: Option<String>,
+    // Optional so an older/leaner caller can omit it; Tauri maps a missing arg to
+    // None, which we treat as "not auto" — the protocol's default order.
+    auto: Option<bool>,
 ) -> Result<State, String> {
+    let auto = auto.unwrap_or(false);
     off_thread(Arc::clone(&state.backend), move |b| {
-        b.connect(profile, node)
+        b.connect(profile, node, auto)
     })
     .await
 }

--- a/ui-desktop/src/App.tsx
+++ b/ui-desktop/src/App.tsx
@@ -19,6 +19,7 @@ import { useTrafficHistory } from "./lib/useTrafficHistory";
 import { formatMbps } from "./lib/format";
 import {
   getAutoconnect,
+  getAutoFastest,
   getKillSwitch,
   getLastProfileId,
   setKillSwitch as persistKillSwitch,
@@ -128,7 +129,14 @@ export function App() {
         if (connected || phase === "connecting") {
           await tenebra.disconnect();
         } else if (selectedProfileId) {
-          await tenebra.connect(selectedProfileId, selectedNodeId || undefined);
+          // No explicit node → let the core choose. The persisted "auto-select
+          // fastest" preference decides between ping-ranked and protocol-fallback
+          // order; it is read fresh (like autoconnect) so a Settings toggle takes
+          // effect on the next connect without prop-threading. When a node is
+          // selected, auto is moot — the core honours the explicit exit.
+          const node = selectedNodeId || undefined;
+          const auto = node ? undefined : getAutoFastest();
+          await tenebra.connect(selectedProfileId, node, auto);
         }
       } catch {
         // Surfaced on the state/log channels.
@@ -229,7 +237,9 @@ export function App() {
     }
     const lastId = getLastProfileId();
     if (lastId && profiles.some((p) => p.id === lastId)) {
-      void tenebra.connect(lastId).catch(() => {});
+      // Launch reconnect names no node, so honour the fastest-node preference
+      // here too — same source of truth as the manual connect above.
+      void tenebra.connect(lastId, undefined, getAutoFastest()).catch(() => {});
     }
   }, [tenebra.ready, profiles, phase, tenebra]);
 

--- a/ui-desktop/src/api/client.test.ts
+++ b/ui-desktop/src/api/client.test.ts
@@ -98,15 +98,27 @@ describe("api command wrappers", () => {
     expect(mockInvoke).toHaveBeenCalledWith("connect", {
       profile: "p1",
       node: "node-1",
+      auto: undefined,
     });
   });
 
-  it("connect passes an undefined node for auto-select", async () => {
+  it("connect passes undefined node/auto for the default selection", async () => {
     mockInvoke.mockResolvedValueOnce(sampleState);
     await api.connect("p1");
     expect(mockInvoke).toHaveBeenCalledWith("connect", {
       profile: "p1",
       node: undefined,
+      auto: undefined,
+    });
+  });
+
+  it("connect forwards the auto flag for fastest-node selection", async () => {
+    mockInvoke.mockResolvedValueOnce(sampleState);
+    await api.connect("p1", undefined, true);
+    expect(mockInvoke).toHaveBeenCalledWith("connect", {
+      profile: "p1",
+      node: undefined,
+      auto: true,
     });
   });
 

--- a/ui-desktop/src/api/client.ts
+++ b/ui-desktop/src/api/client.ts
@@ -54,8 +54,12 @@ export const api = {
     }).then((r) => r.profile);
   },
 
-  connect(profile: string, node?: string): Promise<State> {
-    return invoke<State>("connect", { profile, node });
+  // `node` names an explicit exit; without one, `auto` chooses the core's
+  // candidate ordering — true ranks nodes by measured ping (fastest first),
+  // false (the default) keeps the protocol-fallback order. The core ignores
+  // `auto` when a node is given.
+  connect(profile: string, node?: string, auto?: boolean): Promise<State> {
+    return invoke<State>("connect", { profile, node, auto });
   },
 
   disconnect(): Promise<State> {

--- a/ui-desktop/src/api/client.ts
+++ b/ui-desktop/src/api/client.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 import type {
+  BatchImportResult,
   LogEvent,
   PingResult,
   Profile,
@@ -42,6 +43,15 @@ export const api = {
     return invoke<{ profile: Profile }>("import_link", { link, name }).then(
       (r) => r.profile,
     );
+  },
+
+  // Batch import: several share links (pasted block or a parsed .txt list) into a
+  // single multi-server profile. The core splits, de-duplicates and skips
+  // unparseable lines, returning how many it imported and skipped so the UI can
+  // report the outcome. `links` may carry multi-line strings; an empty result
+  // (no valid links) rejects.
+  importLinks(links: string[], name?: string): Promise<BatchImportResult> {
+    return invoke<BatchImportResult>("import_links", { links, name });
   },
 
   removeProfile(profile: string): Promise<void> {

--- a/ui-desktop/src/api/types.ts
+++ b/ui-desktop/src/api/types.ts
@@ -59,6 +59,18 @@ export interface PingResult {
   ok: boolean;
 }
 
+/**
+ * Result of a batch link import (`import_links`): the single profile built from
+ * all the valid links, plus how many links were imported and how many were
+ * skipped because they didn't parse. Mirror of the core's wrapped response — the
+ * UI surfaces "imported N, skipped M".
+ */
+export interface BatchImportResult {
+  profile: Profile;
+  imported: number;
+  skipped: number;
+}
+
 // Events the core pushes without being asked.
 
 export type LogLevel = "info" | "warn" | "error";

--- a/ui-desktop/src/i18n/strings.ts
+++ b/ui-desktop/src/i18n/strings.ts
@@ -168,6 +168,9 @@ export interface Strings {
     launchAtLoginHint: string;
     autoconnect: string;
     autoconnectHint: string;
+    /** "Auto-select fastest node" toggle label and its explanation. */
+    autoFastest: string;
+    autoFastestHint: string;
   };
 
   logs: {
@@ -365,6 +368,9 @@ const en: Strings = {
     launchAtLoginHint: "Start Tenebra when you sign in.",
     autoconnect: "Connect on launch",
     autoconnectHint: "Reconnect the last used profile when Tenebra starts.",
+    autoFastest: "Auto-select fastest node",
+    autoFastestHint:
+      "When you connect without picking a node, ping the servers and use the fastest one. Blocked servers are skipped automatically.",
   },
   logs: {
     title: "Logs",
@@ -551,6 +557,9 @@ const ru: Strings = {
     launchAtLoginHint: "Открывать Tenebra при входе в систему.",
     autoconnect: "Подключаться при запуске",
     autoconnectHint: "Восстанавливать последний профиль при старте Tenebra.",
+    autoFastest: "Выбирать самый быстрый узел",
+    autoFastestHint:
+      "При подключении без выбора узла пинговать серверы и использовать самый быстрый. Заблокированные серверы пропускаются автоматически.",
   },
   logs: {
     title: "Журнал",

--- a/ui-desktop/src/i18n/strings.ts
+++ b/ui-desktop/src/i18n/strings.ts
@@ -124,6 +124,8 @@ export interface Strings {
       urlPlaceholder: string;
       link: string;
       linkPlaceholder: string;
+      /** Hint under the link field noting several links (one per line) are OK. */
+      linkHint: string;
       pickFile: string;
       fileHint: string;
       paste: string;
@@ -133,6 +135,11 @@ export interface Strings {
       qrScanning: string;
       submit: string;
       importing: string;
+      /**
+       * Outcome of a batch import, with `{imported}` and `{skipped}` counts
+       * substituted in.
+       */
+      batchResult: string;
     };
   };
 
@@ -218,6 +225,8 @@ export interface Strings {
     qrNotFound: string;
     qrUnsupported: string;
     qrDecodeFailed: string;
+    /** No line in the pasted text or chosen file parsed as a valid link. */
+    batchEmpty: string;
   };
 }
 
@@ -325,6 +334,7 @@ const en: Strings = {
       urlPlaceholder: "https://…",
       link: "Server link",
       linkPlaceholder: "vless://…  ·  hysteria2://…  ·  ss://…",
+      linkHint: "Paste one link, or several — one per line — to import them as a single profile.",
       pickFile: "Choose file…",
       fileHint: "A text file with one server link per line.",
       paste: "Paste",
@@ -334,6 +344,7 @@ const en: Strings = {
       qrScanning: "Scanning…",
       submit: "Import",
       importing: "Importing…",
+      batchResult: "Imported {imported}, skipped {skipped}.",
     },
   },
   settings: {
@@ -407,6 +418,7 @@ const en: Strings = {
     qrNotFound: "No QR code found in that image.",
     qrUnsupported: "QR scanning isn't available here. Paste the link instead.",
     qrDecodeFailed: "Couldn't read that image.",
+    batchEmpty: "No valid server links found.",
   },
 };
 
@@ -514,6 +526,7 @@ const ru: Strings = {
       urlPlaceholder: "https://…",
       link: "Ссылка на сервер",
       linkPlaceholder: "vless://…  ·  hysteria2://…  ·  ss://…",
+      linkHint: "Вставьте одну ссылку или сразу несколько — по одной в строке — они станут одним профилем.",
       pickFile: "Выбрать файл…",
       fileHint: "Текстовый файл: по одной ссылке на сервер в строке.",
       paste: "Вставить",
@@ -523,6 +536,7 @@ const ru: Strings = {
       qrScanning: "Сканирую…",
       submit: "Импортировать",
       importing: "Импортирую…",
+      batchResult: "Импортировано: {imported}, пропущено: {skipped}.",
     },
   },
   settings: {
@@ -596,6 +610,7 @@ const ru: Strings = {
     qrNotFound: "В этом изображении нет QR-кода.",
     qrUnsupported: "Сканирование QR здесь недоступно. Вставьте ссылку вручную.",
     qrDecodeFailed: "Не удалось прочитать изображение.",
+    batchEmpty: "Не найдено ни одной корректной ссылки на сервер.",
   },
 };
 

--- a/ui-desktop/src/lib/settings.ts
+++ b/ui-desktop/src/lib/settings.ts
@@ -6,6 +6,7 @@
 const AUTOCONNECT_KEY = "tenebra.autoconnect";
 const LAST_PROFILE_KEY = "tenebra.lastProfile";
 const KILLSWITCH_KEY = "tenebra.killSwitch";
+const AUTO_FASTEST_KEY = "tenebra.autoFastest";
 
 /** Whether "connect on launch" is enabled. Off unless explicitly turned on. */
 export function getAutoconnect(): boolean {
@@ -37,4 +38,18 @@ export function getKillSwitch(): boolean {
 
 export function setKillSwitch(on: boolean): void {
   localStorage.setItem(KILLSWITCH_KEY, on ? "1" : "0");
+}
+
+/**
+ * Whether "auto-select fastest node" is enabled. When on, a connect without an
+ * explicit node asks the core to ping every candidate and pick the lowest-RTT
+ * one (anti-DPI fallback still applies). Off unless explicitly turned on, so the
+ * default stays the core's protocol-fallback order.
+ */
+export function getAutoFastest(): boolean {
+  return localStorage.getItem(AUTO_FASTEST_KEY) === "1";
+}
+
+export function setAutoFastest(on: boolean): void {
+  localStorage.setItem(AUTO_FASTEST_KEY, on ? "1" : "0");
 }

--- a/ui-desktop/src/screens/ProfilesScreen.import.test.tsx
+++ b/ui-desktop/src/screens/ProfilesScreen.import.test.tsx
@@ -17,6 +17,9 @@ vi.mock("../api", async (importOriginal) => {
       ...actual.api,
       importSubscription: vi.fn().mockResolvedValue(makeProfileStub()),
       importLink: vi.fn().mockResolvedValue(makeProfileStub()),
+      importLinks: vi
+        .fn()
+        .mockResolvedValue({ profile: makeProfileStub(), imported: 2, skipped: 1 }),
     },
   };
 });
@@ -46,6 +49,13 @@ async function openDialog() {
 describe("ProfilesScreen import dialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The suite's restoreMocks wipes resolved values between tests, so re-arm the
+    // ones whose return value (not just call args) the assertions depend on.
+    vi.mocked(api.importLinks).mockResolvedValue({
+      profile: makeProfileStub() as never,
+      imported: 2,
+      skipped: 1,
+    });
   });
 
   describe("subscription tab", () => {
@@ -122,6 +132,73 @@ describe("ProfilesScreen import dialog", () => {
       await user.click(dialog.getByRole("button", { name: "Import" }));
 
       expect(api.importLink).toHaveBeenCalledWith(link, "My node");
+    });
+
+    it("batches several pasted links into one import and reports the counts", async () => {
+      const { user, dialog } = await goToLinkTab();
+
+      // Two links plus a comment and a blank line: the comment/blank are filtered
+      // out before the call, and because there are 2+ links it routes to the
+      // batch importer (not the single-link one).
+      const pasted = [
+        "vless://a@a.example.com:443",
+        "# a comment",
+        "",
+        "trojan://b@b.example.com:443",
+      ].join("\n");
+      const textarea = dialog.getByPlaceholderText(/vless:\/\//);
+      // Paste in one shot; typing newline-by-newline through a textarea is brittle.
+      await user.click(textarea);
+      await user.paste(pasted);
+      await user.click(dialog.getByRole("button", { name: "Import" }));
+
+      expect(api.importLink).not.toHaveBeenCalled();
+      expect(api.importLinks).toHaveBeenCalledWith(
+        ["vless://a@a.example.com:443", "trojan://b@b.example.com:443"],
+        undefined,
+      );
+      // The dialog stays open and shows the imported/skipped outcome.
+      expect(
+        await dialog.findByText("Imported 2, skipped 1."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("file tab", () => {
+    async function goToFileTab() {
+      const ctx = await openDialog();
+      await ctx.user.click(ctx.dialog.getByRole("tab", { name: "File" }));
+      return ctx;
+    }
+
+    it("imports the links from a chosen .txt file as one batch", async () => {
+      const { user, dialog } = await goToFileTab();
+
+      // A file with two links, a comment and a blank line. linkLines() drops the
+      // comment/blank, so the batch importer sees exactly the two links.
+      const body = [
+        "vless://a@a.example.com:443",
+        "# header",
+        "",
+        "ss://b@203.0.113.5:8388",
+      ].join("\n");
+      const file = new File([body], "servers.txt", { type: "text/plain" });
+
+      // The visible "Choose file…" button proxies to a hidden <input type=file>;
+      // upload straight to the input the dialog renders.
+      const input = dialog
+        .getByText("Choose file…")
+        .closest(".prof-field")!
+        .querySelector('input[type="file"]') as HTMLInputElement;
+      await user.upload(input, file);
+
+      expect(api.importLinks).toHaveBeenCalledWith(
+        ["vless://a@a.example.com:443", "ss://b@203.0.113.5:8388"],
+        undefined,
+      );
+      expect(
+        await dialog.findByText("Imported 2, skipped 1."),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/ui-desktop/src/screens/ProfilesScreen.qr.test.tsx
+++ b/ui-desktop/src/screens/ProfilesScreen.qr.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ProfilesScreen } from "./ProfilesScreen";
+import { renderWithProviders } from "../test/renderWithProviders";
+import { makeProfile, makeTenebra } from "../test/fixtures";
+import { api } from "../api";
+
+// The QR tab decodes an image to a string and then routes it through the right
+// import path: a web URL becomes a subscription, anything else a server link.
+// We mock the decoder (the decode itself is covered in lib/qr.test.ts) and the
+// import calls so the test asserts only the routing the dialog owns.
+vi.mock("../lib/qr", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/qr")>();
+  return {
+    ...actual,
+    isQrDecodingSupported: () => true,
+    decodeQrFromBlob: vi.fn(),
+  };
+});
+
+vi.mock("../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      importSubscription: vi
+        .fn()
+        .mockResolvedValue({ id: "x", name: "x", source: "subscription", nodes: [] }),
+      importLink: vi
+        .fn()
+        .mockResolvedValue({ id: "x", name: "x", source: "manual", nodes: [] }),
+    },
+  };
+});
+
+import { decodeQrFromBlob } from "../lib/qr";
+
+async function openQrTab() {
+  const tenebra = makeTenebra({ profiles: [makeProfile()] });
+  renderWithProviders(
+    <ProfilesScreen
+      tenebra={tenebra}
+      selectedProfileId={null}
+      onSelectProfile={vi.fn()}
+    />,
+  );
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Import" }));
+  const dialog = within(screen.getByRole("dialog"));
+  await user.click(dialog.getByRole("tab", { name: "QR code" }));
+  return { user, dialog };
+}
+
+/** The hidden image <input> behind the "Choose image…" button. */
+function qrInput(dialog: ReturnType<typeof within>): HTMLInputElement {
+  return dialog
+    .getByText("Choose image…")
+    .closest(".prof-field")!
+    .querySelector('input[type="file"]') as HTMLInputElement;
+}
+
+const image = new File(["fake-bytes"], "code.png", { type: "image/png" });
+
+describe("ProfilesScreen QR import routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes a decoded subscription URL to import_subscription", async () => {
+    vi.mocked(decodeQrFromBlob).mockResolvedValue("https://example.invalid/sub");
+    const { user, dialog } = await openQrTab();
+
+    await user.upload(qrInput(dialog), image);
+
+    expect(api.importSubscription).toHaveBeenCalledTimes(1);
+    expect(api.importSubscription).toHaveBeenCalledWith(
+      "https://example.invalid/sub",
+      "https://example.invalid/sub",
+    );
+    expect(api.importLink).not.toHaveBeenCalled();
+  });
+
+  it("routes a decoded share link to import_link", async () => {
+    vi.mocked(decodeQrFromBlob).mockResolvedValue(
+      "vless://abc@a.example.com:443#node",
+    );
+    const { user, dialog } = await openQrTab();
+
+    await user.upload(qrInput(dialog), image);
+
+    expect(api.importLink).toHaveBeenCalledTimes(1);
+    expect(api.importLink).toHaveBeenCalledWith(
+      "vless://abc@a.example.com:443#node",
+      undefined,
+    );
+    expect(api.importSubscription).not.toHaveBeenCalled();
+  });
+
+  it("shows the QR error copy when decoding fails", async () => {
+    const { QrError } = await import("../lib/qr");
+    vi.mocked(decodeQrFromBlob).mockRejectedValue(new QrError("notFound"));
+    const { user, dialog } = await openQrTab();
+
+    await user.upload(qrInput(dialog), image);
+
+    expect(
+      await dialog.findByText("No QR code found in that image."),
+    ).toBeInTheDocument();
+    expect(api.importSubscription).not.toHaveBeenCalled();
+    expect(api.importLink).not.toHaveBeenCalled();
+  });
+});

--- a/ui-desktop/src/screens/ProfilesScreen.tsx
+++ b/ui-desktop/src/screens/ProfilesScreen.tsx
@@ -331,6 +331,31 @@ function ProfileCard({
 
 type ImportTab = "subscription" | "link" | "file" | "qr";
 
+// Pull the importable link lines out of a pasted block or file body: trim each
+// line and drop blanks and comments (# or //), mirroring how the core's batch
+// parser decides what even counts as a candidate. The count tells the link tab
+// whether the user pasted one link (single import) or several (batch), and feeds
+// both the textarea and the .txt-file paths so they behave identically.
+function linkLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l !== "" && !l.startsWith("#") && !l.startsWith("//"));
+}
+
+// Read a chosen file's text in the webview with FileReader. We prefer this over
+// File.text() / the Tauri fs plugin: it works inside WebView2 with no extra
+// capability or Rust file command, and degrades to a rejected promise the caller
+// can report rather than an unhandled throw.
+function readFileText(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(reader.error ?? new Error("file read failed"));
+    reader.readAsText(file);
+  });
+}
+
 // Map the typed clipboard/QR failures to a user-facing message. Kept beside the
 // dialog so both the paste button and the QR panel report failures the same way.
 function clipboardErrorMessage(err: unknown, t: Strings): string {
@@ -368,6 +393,10 @@ function ImportDialog({ tenebra, onClose }: ImportDialogProps) {
   const [url, setUrl] = useState("");
   const [link, setLink] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // A success line for batch imports ("imported N, skipped M"). Unlike a single
+  // import — which closes the dialog on success — a batch keeps the dialog open
+  // so the user sees how many links landed and how many were skipped.
+  const [result, setResult] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [scanning, setScanning] = useState(false);
 
@@ -396,12 +425,37 @@ function ImportDialog({ tenebra, onClose }: ImportDialogProps) {
   async function finish(action: () => Promise<unknown>) {
     setBusy(true);
     setError(null);
+    setResult(null);
     try {
       await action();
       await tenebra.refreshProfiles();
       onClose();
     } catch {
       setError(t.errors.generic);
+      setBusy(false);
+    }
+  }
+
+  // Batch import of several links. On success the dialog stays open and reports
+  // the imported/skipped counts (so the user learns a few links were dropped)
+  // rather than vanishing. An empty result — the core found no valid links —
+  // surfaces a clear message instead of the generic one.
+  async function finishBatch(links: string[]) {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await api.importLinks(links, name.trim() || undefined);
+      await tenebra.refreshProfiles();
+      setResult(
+        t.profiles.import.batchResult
+          .replace("{imported}", String(res.imported))
+          .replace("{skipped}", String(res.skipped)),
+      );
+    } catch {
+      // The core rejects a batch with no parseable links; tell the user plainly.
+      setError(t.errors.batchEmpty);
+    } finally {
       setBusy(false);
     }
   }
@@ -419,27 +473,41 @@ function ImportDialog({ tenebra, onClose }: ImportDialogProps) {
   }
 
   function submitLink() {
-    if (!link.trim()) {
-      setError(t.errors.linkRequired);
-      return;
-    }
-    void finish(() => api.importLink(link.trim(), name.trim() || undefined));
-  }
-
-  async function onFileChosen(file: File) {
-    const lines = (await file.text())
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean);
+    const lines = linkLines(link);
     if (lines.length === 0) {
       setError(t.errors.linkRequired);
       return;
     }
-    void finish(async () => {
-      for (const line of lines) {
-        await api.importLink(line);
-      }
-    });
+    // One link keeps the single-import path (a one-server manual profile);
+    // several links collapse into one multi-server profile via the batch import,
+    // which also reports how many were skipped.
+    if (lines.length === 1) {
+      void finish(() => api.importLink(lines[0], name.trim() || undefined));
+    } else {
+      void finishBatch(lines);
+    }
+  }
+
+  async function onFileChosen(file: File) {
+    let text: string;
+    try {
+      // Read via FileReader rather than file.text(): it needs no new Tauri
+      // plugin or Rust file command (it runs entirely in the webview), and it is
+      // the broadly-supported path. A read failure (e.g. the file vanished) is
+      // surfaced rather than thrown.
+      text = await readFileText(file);
+    } catch {
+      setError(t.errors.generic);
+      return;
+    }
+    const lines = linkLines(text);
+    if (lines.length === 0) {
+      setError(t.errors.linkRequired);
+      return;
+    }
+    // A .txt list is always a batch — even a single line — so the user gets a
+    // consistent imported/skipped report and one profile holding every server.
+    void finishBatch(lines);
   }
 
   // Fill the active field from the clipboard so the user needn't paste by hand.
@@ -530,6 +598,7 @@ function ImportDialog({ tenebra, onClose }: ImportDialogProps) {
               onClick={() => {
                 setTab(id);
                 setError(null);
+                setResult(null);
               }}
             >
               {tabLabels[id]}
@@ -584,6 +653,7 @@ function ImportDialog({ tenebra, onClose }: ImportDialogProps) {
                 placeholder={t.profiles.import.linkPlaceholder}
                 onChange={(e) => setLink(e.target.value)}
               />
+              <p className="prof-field-hint">{t.profiles.import.linkHint}</p>
               <div className="prof-field-actions">
                 <button
                   type="button"
@@ -672,6 +742,11 @@ function ImportDialog({ tenebra, onClose }: ImportDialogProps) {
           {error && (
             <p className="prof-error" role="alert">
               {error}
+            </p>
+          )}
+          {result && (
+            <p className="prof-success" role="status">
+              {result}
             </p>
           )}
         </div>

--- a/ui-desktop/src/screens/SettingsScreen.test.tsx
+++ b/ui-desktop/src/screens/SettingsScreen.test.tsx
@@ -132,6 +132,50 @@ describe("SettingsScreen", () => {
     });
   });
 
+  describe("startup", () => {
+    // The switch's accessible name is its own text ("ON"/"OFF"), not the sibling
+    // label, so locate the row by its label text and grab the switch within it.
+    function fastestToggle(): HTMLElement {
+      const label = screen.getByText("Auto-select fastest node");
+      const row = label.closest(".set-row");
+      if (!row) {
+        throw new Error("auto-fastest row not found");
+      }
+      const toggle = row.querySelector('[role="switch"]');
+      if (!toggle) {
+        throw new Error("auto-fastest switch not found");
+      }
+      return toggle as HTMLElement;
+    }
+
+    it("auto-select-fastest reflects and persists the stored preference", async () => {
+      const tenebra = makeTenebra({ state: { state: "idle" } as State });
+      const user = userEvent.setup();
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      const toggle = fastestToggle();
+      // Starts off (localStorage cleared in beforeEach).
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+      // The choice is written to localStorage so the connect flow can read it.
+      expect(localStorage.getItem("tenebra.autoFastest")).toBe("1");
+
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+      expect(localStorage.getItem("tenebra.autoFastest")).toBe("0");
+    });
+
+    it("auto-select-fastest starts on when previously enabled", () => {
+      localStorage.setItem("tenebra.autoFastest", "1");
+      const tenebra = makeTenebra({ state: { state: "idle" } as State });
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      expect(fastestToggle()).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
   describe("appearance", () => {
     it("applies the chosen theme to the document", async () => {
       const tenebra = makeTenebra({ state: { state: "idle" } as State });

--- a/ui-desktop/src/screens/SettingsScreen.tsx
+++ b/ui-desktop/src/screens/SettingsScreen.tsx
@@ -6,7 +6,12 @@ import type { Tenebra } from "../state/useTenebra";
 import { useI18n } from "../i18n/I18nContext";
 import { useTheme } from "../theme/ThemeContext";
 import type { Language } from "../i18n/strings";
-import { getAutoconnect, setAutoconnect } from "../lib/settings";
+import {
+  getAutoconnect,
+  getAutoFastest,
+  setAutoconnect,
+  setAutoFastest,
+} from "../lib/settings";
 
 interface SettingsScreenProps {
   tenebra: Tenebra;
@@ -21,6 +26,7 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
   const [launchAtLogin, setLaunchAtLogin] = useState(false);
   const [launchBusy, setLaunchBusy] = useState(false);
   const [autoconnect, setAutoconnectState] = useState(getAutoconnect);
+  const [autoFastest, setAutoFastestState] = useState(getAutoFastest);
 
   useEffect(() => {
     let active = true;
@@ -62,6 +68,14 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
     setAutoconnectState((prev) => {
       const next = !prev;
       setAutoconnect(next);
+      return next;
+    });
+  }
+
+  function toggleAutoFastest() {
+    setAutoFastestState((prev) => {
+      const next = !prev;
+      setAutoFastest(next);
       return next;
     });
   }
@@ -352,6 +366,25 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
               {autoconnect ? "▣" : "▢"}
             </span>
             {autoconnect ? "ON" : "OFF"}
+          </button>
+        </div>
+
+        <div className="set-row">
+          <span className="set-row-text">
+            <span className="set-row-label">{t.settings.autoFastest}</span>
+            <span className="set-row-hint">{t.settings.autoFastestHint}</span>
+          </span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={autoFastest}
+            className={`set-switch${autoFastest ? " is-on" : ""}`}
+            onClick={toggleAutoFastest}
+          >
+            <span className="set-switch-box" aria-hidden="true">
+              {autoFastest ? "▣" : "▢"}
+            </span>
+            {autoFastest ? "ON" : "OFF"}
           </button>
         </div>
       </section>

--- a/ui-desktop/src/state/useTenebra.test.ts
+++ b/ui-desktop/src/state/useTenebra.test.ts
@@ -203,7 +203,20 @@ describe("actions", () => {
       await result.current.connect("p1", "node-1");
     });
 
-    expect(mockApi.connect).toHaveBeenCalledWith("p1", "node-1");
+    expect(mockApi.connect).toHaveBeenCalledWith("p1", "node-1", undefined);
+    expect(result.current.state).toEqual(next);
+  });
+
+  it("connect forwards the auto flag to api.connect", async () => {
+    const next: State = { state: "connecting", profile: "p1" };
+    mockApi.connect.mockResolvedValue(next);
+    const { result } = await mountReady();
+
+    await act(async () => {
+      await result.current.connect("p1", undefined, true);
+    });
+
+    expect(mockApi.connect).toHaveBeenCalledWith("p1", undefined, true);
     expect(result.current.state).toEqual(next);
   });
 

--- a/ui-desktop/src/state/useTenebra.ts
+++ b/ui-desktop/src/state/useTenebra.ts
@@ -43,7 +43,7 @@ export interface Tenebra {
   profiles: Profile[];
   logs: LogLine[];
 
-  connect: (profile: string, node?: string) => Promise<void>;
+  connect: (profile: string, node?: string, auto?: boolean) => Promise<void>;
   disconnect: () => Promise<void>;
   setRouting: (mode: RoutingMode) => Promise<void>;
   setSplit: (mode: SplitMode, apps: string[]) => Promise<void>;
@@ -151,10 +151,13 @@ export function useTenebra(): Tenebra {
     };
   }, [appendLog]);
 
-  const connect = useCallback(async (profile: string, node?: string) => {
-    const next = await api.connect(profile, node);
-    setState(next);
-  }, []);
+  const connect = useCallback(
+    async (profile: string, node?: string, auto?: boolean) => {
+      const next = await api.connect(profile, node, auto);
+      setState(next);
+    },
+    [],
+  );
 
   const disconnect = useCallback(async () => {
     const next = await api.disconnect();

--- a/ui-desktop/src/styles/profiles.css
+++ b/ui-desktop/src/styles/profiles.css
@@ -491,6 +491,15 @@
   color: var(--signal);
 }
 
+/* batch-import outcome = the positive tone, distinct from an error */
+.prof-success {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-body);
+  color: var(--good);
+}
+
 .prof-modal-actions {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
﻿Two MVP gaps from the client brief, each opt-in and backward-compatible.

## Fastest-node auto-selection (by latency)
When enabled (Settings -> Startup), a node-less connect probes each candidate's TCP latency and tries them fastest-first instead of by protocol preference. The anti-DPI fallback is preserved: a blocked-but-fast node still yields to the next, and unreachable probes sort last but are still attempted. Off by default; an explicit node bypasses it. Last-good only breaks an exact-latency tie so an equally-fast field does not churn across reconnects.

## Multi-link and QR import
- The Link tab now accepts several links pasted together, and a new File tab imports a `.txt` list. Both build a single profile with many servers, skipping blank, commented and unparseable lines and reporting how many were imported versus skipped.
- The QR tab decodes a chosen image (PNG/JPG) and routes it to a subscription or single-link import.
- File reading uses a plain `<input type="file">` plus `FileReader`, so no extra Tauri plugin or capabilities are required.

## Verify
- `go build ./...`, `go vet ./...`, `go test -count=1 ./...` all green
- `tsc --noEmit` clean, `vitest` 163 passed (+5 over baseline)
- `cargo check` and `cargo test --lib` green (63 passed)
