### PR TITLE
Kill switch and switchable TUN stack

### DIFF
--- a/core/control/connect.go
+++ b/core/control/connect.go
@@ -29,9 +29,10 @@ const (
 )
 
 // handleConnect starts a connection to a profile. It validates the profile,
-// builds the fallback candidate list (collapsed to a single node when the
-// request names one), and kicks off the background fallback loop. It returns as
-// soon as the attempt is launched; progress arrives as state events.
+// then hands off to startConnect, which builds the fallback candidate list
+// (collapsed to a single node when the request names one) and kicks off the
+// background fallback loop. It returns as soon as the attempt is launched;
+// progress arrives as state events.
 func (d *Daemon) handleConnect(ctx context.Context, req Request) Response {
 	if req.Profile == "" {
 		return newError(req.ID, "connect: missing profile")
@@ -44,14 +45,37 @@ func (d *Daemon) handleConnect(ctx context.Context, req Request) Response {
 		return newError(req.ID, "connect: profile has no servers")
 	}
 
+	// A user-driven connect opens a fresh kill-switch relaunch budget.
+	d.mu.Lock()
+	d.relaunches = 0
+	d.mu.Unlock()
+
+	st, err := d.startConnect(ctx, p, req.Node, req.Auto)
+	if err != nil {
+		return newError(req.ID, err.Error())
+	}
+	resp, err := newResult(req.ID, st)
+	if err != nil {
+		return newError(req.ID, err.Error())
+	}
+	return resp
+}
+
+// startConnect launches a connection attempt to profile p and returns the
+// connecting state it reported. It is the shared engine behind the connect
+// command, the live re-apply of tun/kill-switch options, and the kill-switch
+// relaunch of a dead tunnel — all three are "start sing-box against the current
+// options", differing only in how the candidate set is chosen. It returns as
+// soon as the fallback loop is launched.
+func (d *Daemon) startConnect(ctx context.Context, p profile.Profile, explicitNode string, auto bool) (State, error) {
 	// Build the fallback candidates. An explicit node request collapses the walk
 	// to that single node: the user asked for a specific exit, so we honour it and
 	// do not silently wander to another protocol behind their back. Without an
 	// explicit node we hand the machine every server and let the ordering plus the
 	// per-profile last-good decide the sequence.
-	candidates, err := buildCandidates(p, req.Node)
+	candidates, err := buildCandidates(p, explicitNode)
 	if err != nil {
-		return newError(req.ID, err.Error())
+		return State{}, err
 	}
 
 	// Choose the candidate ordering. The default is protocol preference (the
@@ -63,7 +87,7 @@ func (d *Daemon) handleConnect(ctx context.Context, req Request) Response {
 	// next candidate when the lead's connect-probe is blocked) is preserved in
 	// both modes.
 	var m *fallback.Machine
-	if req.Auto && req.Node == "" {
+	if auto && explicitNode == "" {
 		// pingCandidates dials only the candidate servers, concurrently and
 		// briefly (see pingOne's pingDialTimeout), so probing never blocks the
 		// connect path for long. Unreachable candidates fall to the back of the
@@ -118,11 +142,36 @@ func (d *Daemon) handleConnect(ctx context.Context, req Request) Response {
 	// state events from the loop.
 	st := State{State: StateConnecting, Profile: p.ID, Routing: string(ro.Mode)}
 	d.setState(st)
-	resp, err := newResult(req.ID, st)
-	if err != nil {
-		return newError(req.ID, err.Error())
+	return d.snapshotState(), nil
+}
+
+// reapplyLive pushes the current routing/tun options onto a live tunnel by
+// restarting sing-box on the node it is already connected to. strict_route and
+// the tun stack are startup options of the inbound — sing-box cannot change
+// them on a running process — so "apply now" necessarily means a process swap.
+// What it does NOT mean is a full reconnect: the candidate set is pinned to the
+// current node (no fallback walk, no re-selection), the state dips through
+// connecting only for the swap-and-probe, and a probe failure surfaces as an
+// error state exactly like any dropped tunnel.
+//
+// When nothing is connected this is a no-op: the recorded options simply apply
+// on the next connect. If the live profile/node has meanwhile vanished from the
+// store, the running tunnel is left untouched (old options and all) and the
+// change is logged as deferred — a settings toggle must never kill a working
+// tunnel without bringing one back.
+func (d *Daemon) reapplyLive() {
+	cur := d.snapshotState()
+	if cur.State != StateConnected || cur.Profile == "" || cur.Node == "" {
+		return
 	}
-	return resp
+	p, ok := d.store.Get(cur.Profile)
+	if !ok {
+		d.emitLog(LogWarn, "re-apply: connected profile no longer stored; the change applies on the next connect")
+		return
+	}
+	if _, err := d.startConnect(context.Background(), p, cur.Node, false); err != nil {
+		d.emitLog(LogWarn, fmt.Sprintf("re-apply: %v; the change applies on the next connect", err))
+	}
 }
 
 // pingCandidates measures the TCP round-trip to each candidate's server and
@@ -158,6 +207,12 @@ func (d *Daemon) pingCandidates(ctx context.Context, p profile.Profile, candidat
 // handleDisconnect tears the tunnel down to idle and returns the resulting
 // state. It is a no-op when nothing is connected.
 func (d *Daemon) handleDisconnect(req Request) Response {
+	// An explicit disconnect also closes any kill-switch relaunch episode: the
+	// user asked for the tunnel to be down, so nothing may bring it back.
+	d.mu.Lock()
+	d.relaunches = 0
+	d.mu.Unlock()
+
 	d.teardown(StateIdle, "", "")
 	st := d.snapshotState()
 	resp, err := newResult(req.ID, st)
@@ -363,10 +418,12 @@ func (d *Daemon) startLifecycle(ctx context.Context, gen uint64, profileID, node
 
 // watchProcess waits for either the process to exit or the connection to be torn
 // down. A process exit while this is still the live generation becomes an error
-// state (the tunnel dropped); a clean teardown just returns. Unlike before, it no
-// longer promotes connecting->connected on a timer: the fallback loop promotes to
-// connected only after a successful connectivity probe, so by the time this
-// goroutine runs the state is already connected.
+// state (the tunnel dropped) — unless the kill switch is armed, in which case
+// the daemon relaunches the tunnel on the same node (see killSwitchRelaunch). A
+// clean teardown just returns. Unlike before, it no longer promotes
+// connecting->connected on a timer: the fallback loop promotes to connected only
+// after a successful connectivity probe, so by the time this goroutine runs the
+// state is already connected.
 func (d *Daemon) watchProcess(ctx context.Context, gen uint64, profileID, nodeID string, done <-chan error) {
 	for {
 		select {
@@ -381,10 +438,71 @@ func (d *Daemon) watchProcess(ctx context.Context, gen uint64, profileID, nodeID
 				msg = err.Error()
 			}
 			d.emitLog(LogError, "tunnel process exited: "+msg)
+			if d.killSwitchRelaunch(gen, profileID, nodeID) {
+				return // the relaunch owns the state from here
+			}
 			d.setState(State{State: StateError, Profile: profileID, Node: nodeID, Error: msg, Routing: d.snapshotState().Routing})
 			return
 		}
 	}
+}
+
+// maxRelaunches bounds consecutive kill-switch relaunches so a tunnel that dies
+// on every start can't churn processes forever. The counter resets on an
+// explicit connect or disconnect, so a user retry always gets a fresh budget.
+const maxRelaunches = 5
+
+// killSwitchRelaunch restarts a tunnel whose process died unexpectedly, if (and
+// only if) the kill switch is armed. It reports whether it took ownership of the
+// state; false means the caller should fall through to the plain error state.
+//
+// Why restart at all: strict_route only holds while sing-box runs — the moment
+// the process dies, its filter rules and the tun route die with it, and traffic
+// would fall back to the physical interface. The honest mitigation the daemon
+// can offer is to put the tunnel (and its filters) back immediately, pinned to
+// the node the user was on. During the gap the OS is unprotected; that window
+// is why this relaunches eagerly rather than waiting for the user.
+//
+// The relaunch reuses startConnect, which tears down the old connection and
+// waits for its goroutines — including the watcher that called us — so it must
+// run on a fresh goroutine, not on the watcher's own stack (that would
+// deadlock on wg.Wait). The generation is re-checked on that goroutine: if a
+// user connect/disconnect landed meanwhile, the relaunch yields to it.
+func (d *Daemon) killSwitchRelaunch(gen uint64, profileID, nodeID string) bool {
+	d.mu.Lock()
+	armed := d.routing.KillSwitch
+	spent := d.relaunches
+	if armed && spent < maxRelaunches {
+		d.relaunches++
+	}
+	d.mu.Unlock()
+
+	if !armed {
+		return false
+	}
+	if spent >= maxRelaunches {
+		d.emitLog(LogError, fmt.Sprintf("kill switch: tunnel died %d times in a row; giving up on restarts", spent))
+		return false
+	}
+	p, ok := d.store.Get(profileID)
+	if !ok {
+		d.emitLog(LogError, "kill switch: cannot restart, profile no longer stored")
+		return false
+	}
+
+	d.emitLog(LogWarn, "kill switch: tunnel process died, restarting it on the same node")
+	go func() {
+		if !d.isCurrent(gen) {
+			return // a user action superseded the dead connection; let it win
+		}
+		if _, err := d.startConnect(context.Background(), p, nodeID, false); err != nil {
+			d.emitLog(LogError, fmt.Sprintf("kill switch: restart failed: %v", err))
+			d.setState(State{State: StateError, Profile: profileID, Node: nodeID,
+				Error: "tunnel died and could not be restarted: " + err.Error(),
+				Routing: d.snapshotState().Routing})
+		}
+	}()
+	return true
 }
 
 // pollTraffic polls cumulative counters every interval and emits a traffic event
@@ -465,11 +583,12 @@ func (d *Daemon) setState(s State) {
 	if s.Routing == "" {
 		s.Routing = d.state.Routing
 	}
-	// The split config is a daemon-wide setting, not a per-connection one, so it
-	// always tracks the live routing options rather than whatever the transient
-	// State value carried. This keeps status reporting the split correctly across
-	// connect/disconnect transitions without every call site restating it.
-	applySplitToState(&s, d.routing)
+	// The split/kill-switch/tun preferences are daemon-wide settings, not
+	// per-connection ones, so they always track the live options rather than
+	// whatever the transient State value carried. This keeps status reporting
+	// them correctly across connect/disconnect transitions without every call
+	// site restating them.
+	applySettingsToState(&s, d.routing, d.tun)
 	d.state = s
 	emit := d.emit
 	d.mu.Unlock()

--- a/core/control/connect.go
+++ b/core/control/connect.go
@@ -50,7 +50,13 @@ func (d *Daemon) handleConnect(ctx context.Context, req Request) Response {
 	d.relaunches = 0
 	d.mu.Unlock()
 
+	// Hold connMu across the transition so an in-flight kill-switch relaunch or
+	// connecting-window reconcile (the only connects that run off this serialized
+	// command loop) cannot interleave: it re-checks the generation under the same
+	// lock and yields to this connect.
+	d.connMu.Lock()
 	st, err := d.startConnect(ctx, p, req.Node, req.Auto)
+	d.connMu.Unlock()
 	if err != nil {
 		return newError(req.ID, err.Error())
 	}
@@ -160,6 +166,10 @@ func (d *Daemon) startConnect(ctx context.Context, p profile.Profile, explicitNo
 // change is logged as deferred — a settings toggle must never kill a working
 // tunnel without bringing one back.
 func (d *Daemon) reapplyLive() {
+	// Serialize with the off-command relaunch/reconcile connects (connMu), same as
+	// the connect command, so the hot-swap can't race one of them.
+	d.connMu.Lock()
+	defer d.connMu.Unlock()
 	cur := d.snapshotState()
 	if cur.State != StateConnected || cur.Profile == "" || cur.Node == "" {
 		return
@@ -213,7 +223,12 @@ func (d *Daemon) handleDisconnect(req Request) Response {
 	d.relaunches = 0
 	d.mu.Unlock()
 
+	// The teardown runs under connMu so its generation bump is authoritative over
+	// an in-flight relaunch/reconcile: that goroutine, blocked on connMu, wakes to
+	// find the generation moved and yields instead of resurrecting the tunnel.
+	d.connMu.Lock()
 	d.teardown(StateIdle, "", "")
+	d.connMu.Unlock()
 	st := d.snapshotState()
 	resp, err := newResult(req.ID, st)
 	if err != nil {
@@ -227,6 +242,11 @@ func (d *Daemon) handleDisconnect(req Request) Response {
 // newState carrying profile/node. Passing StateConnecting is how connect
 // transitions an old connection out before the new one starts; StateIdle is a
 // plain disconnect.
+//
+// Callers hold connMu so the whole transition (this teardown plus whatever start
+// follows it) is serialized against the off-command relaunch/reconcile connects.
+// It waits on d.wg, which never tracks those goroutines (they run under
+// relaunchWG), so the wait cannot deadlock against a connMu holder.
 func (d *Daemon) teardown(newState ConnState, profileID, nodeID string) {
 	d.mu.Lock()
 	cancel := d.cancel
@@ -320,10 +340,16 @@ func (d *Daemon) runFallback(ctx context.Context, loop fallbackLoop) {
 			if d.lastGood != nil {
 				d.lastGood.Set(loop.profileID, attempt.NodeID)
 			}
+			// Capture the connected instant before publishing it, so the uptime the
+			// relaunch budget reads later is measured from a fixed point.
+			connectedAt := d.now()
 			d.setState(State{State: StateConnected, Profile: loop.profileID,
 				Node: attempt.NodeID, Routing: d.snapshotState().Routing})
 			// Hand the live connection off to the watcher/poller and stop looping.
-			d.startLifecycle(ctx, loop.gen, loop.profileID, attempt.NodeID)
+			d.startLifecycle(ctx, loop.gen, loop.profileID, attempt.NodeID, connectedAt)
+			// A kill-switch/tun toggle that landed during the connecting window was
+			// recorded but not baked into this config; reconcile it now.
+			d.reconcileConnectingOptions(loop, attempt.NodeID)
 			return
 		}
 
@@ -399,14 +425,15 @@ const proxySelectorTag = "proxy"
 // connection: a process watcher that turns an unexpected sing-box exit into an
 // error state, and a traffic poller that emits traffic events. Both stop when ctx
 // is cancelled or the generation moves on. It is called once, after a probe has
-// already promoted the state to connected.
-func (d *Daemon) startLifecycle(ctx context.Context, gen uint64, profileID, nodeID string) {
+// already promoted the state to connected; connectedAt is that moment, threaded
+// to the watcher so a later relaunch can tell a recovered tunnel from a crash-loop.
+func (d *Daemon) startLifecycle(ctx context.Context, gen uint64, profileID, nodeID string, connectedAt time.Time) {
 	done := d.runner.Done()
 
 	d.wg.Add(1)
 	go func() {
 		defer d.wg.Done()
-		d.watchProcess(ctx, gen, profileID, nodeID, done)
+		d.watchProcess(ctx, gen, profileID, nodeID, connectedAt, done)
 	}()
 
 	d.wg.Add(1)
@@ -424,7 +451,7 @@ func (d *Daemon) startLifecycle(ctx context.Context, gen uint64, profileID, node
 // connecting->connected on a timer: the fallback loop promotes to connected only
 // after a successful connectivity probe, so by the time this goroutine runs the
 // state is already connected.
-func (d *Daemon) watchProcess(ctx context.Context, gen uint64, profileID, nodeID string, done <-chan error) {
+func (d *Daemon) watchProcess(ctx context.Context, gen uint64, profileID, nodeID string, connectedAt time.Time, done <-chan error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -438,7 +465,7 @@ func (d *Daemon) watchProcess(ctx context.Context, gen uint64, profileID, nodeID
 				msg = err.Error()
 			}
 			d.emitLog(LogError, "tunnel process exited: "+msg)
-			if d.killSwitchRelaunch(gen, profileID, nodeID) {
+			if d.killSwitchRelaunch(gen, profileID, nodeID, d.now().Sub(connectedAt)) {
 				return // the relaunch owns the state from here
 			}
 			d.setState(State{State: StateError, Profile: profileID, Node: nodeID, Error: msg, Routing: d.snapshotState().Routing})
@@ -447,14 +474,25 @@ func (d *Daemon) watchProcess(ctx context.Context, gen uint64, profileID, nodeID
 	}
 }
 
-// maxRelaunches bounds consecutive kill-switch relaunches so a tunnel that dies
-// on every start can't churn processes forever. The counter resets on an
-// explicit connect or disconnect, so a user retry always gets a fresh budget.
+// maxRelaunches bounds kill-switch relaunches of a tunnel stuck in a crash-loop
+// (connect, die within seconds, repeat) so it can't churn processes forever. The
+// counter resets on an explicit connect or disconnect, and also whenever a
+// relaunched tunnel stays connected past relaunchResetAfter — a drop after a
+// healthy stretch is not part of a crash-loop, so it opens a fresh budget (see
+// killSwitchRelaunch). Only rapid, back-to-back deaths spend the budget down.
 const maxRelaunches = 5
+
+// defaultRelaunchReset is how long a relaunched tunnel must hold the connection
+// for its later death to count as a genuine recovery rather than one more turn of
+// a crash-loop: a death after at least this long refunds the relaunch budget, a
+// death sooner keeps spending it. It seeds the daemon's relaunchResetAfter, which
+// is a field so tests can shorten it.
+const defaultRelaunchReset = 30 * time.Second
 
 // killSwitchRelaunch restarts a tunnel whose process died unexpectedly, if (and
 // only if) the kill switch is armed. It reports whether it took ownership of the
 // state; false means the caller should fall through to the plain error state.
+// uptime is how long the dead tunnel held the connection.
 //
 // Why restart at all: strict_route only holds while sing-box runs — the moment
 // the process dies, its filter rules and the tun route die with it, and traffic
@@ -463,14 +501,26 @@ const maxRelaunches = 5
 // the node the user was on. During the gap the OS is unprotected; that window
 // is why this relaunches eagerly rather than waiting for the user.
 //
-// The relaunch reuses startConnect, which tears down the old connection and
-// waits for its goroutines — including the watcher that called us — so it must
-// run on a fresh goroutine, not on the watcher's own stack (that would
-// deadlock on wg.Wait). The generation is re-checked on that goroutine: if a
-// user connect/disconnect landed meanwhile, the relaunch yields to it.
-func (d *Daemon) killSwitchRelaunch(gen uint64, profileID, nodeID string) bool {
+// The budget: a relaunch that held the tunnel up past relaunchResetAfter proved a
+// recovery, not one more turn of a crash-loop, so its eventual death refunds the
+// budget. Only rapid deaths (connect, die within seconds, repeat) spend it down,
+// so a long healthy session survives many isolated drops while a tunnel that
+// truly can't stay up still stops churning after maxRelaunches.
+//
+// The relaunch reuses startConnect, which tears down the old connection and waits
+// for its goroutines — including the watcher that called us — so it must run on a
+// fresh goroutine, not on the watcher's own stack (that would deadlock on
+// wg.Wait). startConnectIfCurrent runs it there, re-checking the generation under
+// connMu so a user connect/disconnect/Close that raced the death wins cleanly.
+func (d *Daemon) killSwitchRelaunch(gen uint64, profileID, nodeID string, uptime time.Duration) bool {
 	d.mu.Lock()
 	armed := d.routing.KillSwitch
+	// Refund the budget when the dead tunnel had stayed up long enough to count as
+	// a recovery; a quick death leaves the counter alone so a crash-loop keeps
+	// spending it.
+	if armed && uptime >= d.relaunchResetAfter {
+		d.relaunches = 0
+	}
 	spent := d.relaunches
 	if armed && spent < maxRelaunches {
 		d.relaunches++
@@ -481,7 +531,7 @@ func (d *Daemon) killSwitchRelaunch(gen uint64, profileID, nodeID string) bool {
 		return false
 	}
 	if spent >= maxRelaunches {
-		d.emitLog(LogError, fmt.Sprintf("kill switch: tunnel died %d times in a row; giving up on restarts", spent))
+		d.emitLog(LogError, fmt.Sprintf("kill switch: relaunched %d times but the tunnel keeps dying within seconds; giving up on automatic restarts", spent))
 		return false
 	}
 	p, ok := d.store.Get(profileID)
@@ -491,18 +541,81 @@ func (d *Daemon) killSwitchRelaunch(gen uint64, profileID, nodeID string) bool {
 	}
 
 	d.emitLog(LogWarn, "kill switch: tunnel process died, restarting it on the same node")
+	d.startConnectIfCurrent(gen, p, nodeID, func(err error) {
+		d.emitLog(LogError, fmt.Sprintf("kill switch: restart failed: %v", err))
+		d.setState(State{State: StateError, Profile: profileID, Node: nodeID,
+			Error:   "tunnel died and could not be restarted: " + err.Error(),
+			Routing: d.snapshotState().Routing})
+	})
+	return true
+}
+
+// startConnectIfCurrent runs a connect to (p, node) on a fresh goroutine, but
+// only if gen is still the live generation when the goroutine wins connMu. It is
+// the single connect path that runs off the serialized command loop — the
+// kill-switch relaunch and the connecting-window options reconcile both use it —
+// so it must not race a user connect/disconnect/Close. connMu serializes it
+// against those (they all hold it); the generation re-check inside that exclusion
+// is what makes a user action authoritative: one that already ran bumped the
+// generation and this yields, one that runs after this claim supersedes the
+// connection it starts through the normal teardown. The goroutine is tracked in
+// relaunchWG (not d.wg, which teardown waits on — that would deadlock) so Close
+// can drain it and never let a connect outlive the daemon. onErr handles a start
+// failure, which each caller logs differently.
+func (d *Daemon) startConnectIfCurrent(gen uint64, p profile.Profile, node string, onErr func(error)) {
+	d.relaunchWG.Add(1)
 	go func() {
-		if !d.isCurrent(gen) {
-			return // a user action superseded the dead connection; let it win
+		defer d.relaunchWG.Done()
+		// Test seam: lets a test park this goroutine before it claims connMu so a
+		// concurrent disconnect/Close is guaranteed to win the race. nil in production.
+		if d.beforeReconnect != nil {
+			d.beforeReconnect()
 		}
-		if _, err := d.startConnect(context.Background(), p, nodeID, false); err != nil {
-			d.emitLog(LogError, fmt.Sprintf("kill switch: restart failed: %v", err))
-			d.setState(State{State: StateError, Profile: profileID, Node: nodeID,
-				Error: "tunnel died and could not be restarted: " + err.Error(),
-				Routing: d.snapshotState().Routing})
+		d.connMu.Lock()
+		defer d.connMu.Unlock()
+		if !d.isCurrent(gen) {
+			return // a user action superseded us between the death and this claim
+		}
+		if _, err := d.startConnect(context.Background(), p, node, false); err != nil {
+			onErr(err)
 		}
 	}()
-	return true
+}
+
+// reconcileConnectingOptions re-applies the kill-switch/tun options to a tunnel
+// that has just come up, if they changed while it was still connecting. The
+// fallback loop pins its routing/tun snapshot at the start of the connect so every
+// candidate builds against a consistent view; the price is that a set_kill_switch
+// or set_tun landing during the warmup+probe window is recorded and reported but
+// not baked into the config that actually came up — and reapplyLive no-ops while
+// the state is still "connecting". Left alone, the live tunnel would run the old
+// options while the state advertises the new ones (e.g. armed in the UI but no
+// strict_route on the wire). Here, right after the state reaches connected, we
+// compare what this loop built against the live options and, on a divergence,
+// hot-swap onto the same node exactly as a post-connect toggle would.
+//
+// It converges: the hot-swap's own connect re-runs this check, and once the
+// options settle it finds no divergence and stops — so a burst of toggles costs at
+// most one extra swap per settled value, not an endless loop. Only the live-reapply
+// options (kill switch, tun stack) are compared; routing mode and split are
+// deferred-to-next-connect by design, matching what reapplyLive itself applies.
+func (d *Daemon) reconcileConnectingOptions(loop fallbackLoop, nodeID string) {
+	d.mu.Lock()
+	curRo := d.routing
+	curTun := d.tun
+	d.mu.Unlock()
+	if loop.ro.KillSwitch == curRo.KillSwitch && loop.tun.Stack == curTun.Stack {
+		return // nothing that applies live changed during the connecting window
+	}
+	p, ok := d.store.Get(loop.profileID)
+	if !ok {
+		d.emitLog(LogWarn, "re-apply: connected profile no longer stored; the change applies on the next connect")
+		return
+	}
+	d.emitLog(LogInfo, "re-apply: options changed while connecting; hot-swapping to apply them")
+	d.startConnectIfCurrent(loop.gen, p, nodeID, func(err error) {
+		d.emitLog(LogWarn, fmt.Sprintf("re-apply: %v; the change applies on the next connect", err))
+	})
 }
 
 // pollTraffic polls cumulative counters every interval and emits a traffic event
@@ -646,7 +759,14 @@ func (d *Daemon) emitProfiles() {
 
 // Close tears down any active connection. The server calls it on shutdown.
 func (d *Daemon) Close() error {
+	d.connMu.Lock()
 	d.teardown(StateIdle, "", "")
+	d.connMu.Unlock()
+	// The teardown above bumped the generation, so any kill-switch relaunch or
+	// connecting-window reconcile still in flight will observe it and abort instead
+	// of starting a tunnel. Wait for those goroutines to unwind (after releasing
+	// connMu, which a parked one needs to make its check) so none outlives us.
+	d.relaunchWG.Wait()
 	return nil
 }
 

--- a/core/control/daemon.go
+++ b/core/control/daemon.go
@@ -87,13 +87,36 @@ type Daemon struct {
 	// watching guards against double-starting the lifecycle goroutines and lets
 	// disconnect wait for them to drain.
 	wg sync.WaitGroup
+	// connMu serializes connection transitions (teardown + the start that follows)
+	// so the two connects that run off the serialized command loop — the
+	// kill-switch relaunch and the connecting-window options reconcile — cannot
+	// interleave with a user connect/disconnect/Close. Held around startConnect and
+	// teardown by every such path; never held while waiting on d.wg's goroutines
+	// (they don't take it), so it introduces no deadlock. Always acquired before mu.
+	connMu sync.Mutex
+	// relaunchWG tracks in-flight off-command connect goroutines (relaunch /
+	// reconcile) separately from d.wg, so Close can wait for them to unwind without
+	// the self-deadlock that tracking them in d.wg would cause (their startConnect
+	// waits on d.wg).
+	relaunchWG sync.WaitGroup
 	// generation increments on every connect so a stale watcher from a previous
 	// connection can tell it has been superseded and stay quiet.
 	generation uint64
-	// relaunches counts consecutive kill-switch relaunches of a dying tunnel
-	// process, so a tunnel that crashes on every start can't churn forever. Reset
-	// by an explicit connect or disconnect. Guarded by mu.
+	// relaunches counts kill-switch relaunches of a tunnel that keeps dying within
+	// relaunchResetAfter of coming up (a crash-loop), so it can't churn forever.
+	// Reset by an explicit connect or disconnect, and refunded when a relaunched
+	// tunnel stays up past that window — so isolated drops over a long session
+	// don't accumulate toward the cap. Guarded by mu.
 	relaunches int
+	// relaunchResetAfter is the uptime past which a relaunched tunnel's later death
+	// refunds the relaunch budget rather than spending it. Injectable for tests;
+	// defaults to defaultRelaunchReset.
+	relaunchResetAfter time.Duration
+	// beforeReconnect, when set, is called at the entry of an off-command connect
+	// goroutine (relaunch / reconcile) before it claims connMu. It is a test seam
+	// for driving the interleaving with a concurrent disconnect/Close; nil in
+	// production.
+	beforeReconnect func()
 
 	// now and dial are injectable for tests; production uses the real clock and
 	// dialer.
@@ -151,6 +174,8 @@ func NewDaemon(store *profile.Store, runner Runner) *Daemon {
 		probeRetry:   defaultProbeRetry,
 		probeTimeout: defaultProbeTimeout,
 		probeBudget:  defaultProbeBudget,
+
+		relaunchResetAfter: defaultRelaunchReset,
 	}
 	var dialer net.Dialer
 	d.dial = dialer.DialContext
@@ -422,9 +447,12 @@ func (d *Daemon) handleRemoveProfile(req Request) Response {
 		return newError(req.ID, "remove_profile: missing profile")
 	}
 	// If we're connected to this profile, tear the tunnel down first so we don't
-	// leave an orphaned process bound to a profile that no longer exists.
+	// leave an orphaned process bound to a profile that no longer exists. Under
+	// connMu so the transition is authoritative over an in-flight relaunch/reconcile.
 	if cur := d.snapshotState(); cur.Profile == req.Profile && cur.State != StateIdle {
+		d.connMu.Lock()
 		d.teardown(StateIdle, "", "")
+		d.connMu.Unlock()
 	}
 	if err := d.store.Remove(req.Profile); err != nil {
 		return newError(req.ID, err.Error())

--- a/core/control/daemon.go
+++ b/core/control/daemon.go
@@ -90,6 +90,10 @@ type Daemon struct {
 	// generation increments on every connect so a stale watcher from a previous
 	// connection can tell it has been superseded and stay quiet.
 	generation uint64
+	// relaunches counts consecutive kill-switch relaunches of a dying tunnel
+	// process, so a tunnel that crashes on every start can't churn forever. Reset
+	// by an explicit connect or disconnect. Guarded by mu.
+	relaunches int
 
 	// now and dial are injectable for tests; production uses the real clock and
 	// dialer.
@@ -122,13 +126,19 @@ type Daemon struct {
 }
 
 // NewDaemon builds a Daemon over a profile store and runner. Routing defaults to
-// smart with normalized DNS; the tun options default to the singbox defaults.
+// smart with normalized DNS; the tun options default to the singbox defaults,
+// with the stack pinned explicitly so the reported state always names it.
 func NewDaemon(store *profile.Store, runner Runner) *Daemon {
 	d := &Daemon{
-		store:    store,
-		runner:   runner,
-		routing:  routing.Options{Mode: routing.ModeSmart}.Normalize(),
-		state:    State{State: StateIdle, Routing: string(routing.ModeSmart)},
+		store:   store,
+		runner:  runner,
+		routing: routing.Options{Mode: routing.ModeSmart}.Normalize(),
+		tun:     singbox.TunOptions{Stack: singbox.StackSystem},
+		state: State{
+			State:    StateIdle,
+			Routing:  string(routing.ModeSmart),
+			TunStack: singbox.StackSystem,
+		},
 		lastGood: fallback.NewMemLastGood(),
 		now:      time.Now,
 		fetch:    subscription.Fetch,
@@ -163,10 +173,10 @@ func (d *Daemon) SetLastGood(lg fallback.LastGood) {
 }
 
 // SetSettings installs a persistent settings store and immediately loads any
-// saved preferences (today: the split config) into the live routing options and
-// the reported state. main wires the disk-backed store here so a split choice
-// survives a restart; tests can install a fake or skip it. Call it before
-// serving — it is not synchronised against an in-flight connect.
+// saved preferences (the split config, the kill switch, the tun stack) into the
+// live options and the reported state. main wires the disk-backed store here so
+// the choices survive a restart; tests can install a fake or skip it. Call it
+// before serving — it is not synchronised against an in-flight connect.
 func (d *Daemon) SetSettings(store settingsStore) {
 	d.settings = store
 	ps := store.Load()
@@ -175,8 +185,14 @@ func (d *Daemon) SetSettings(store settingsStore) {
 	mode, apps := splitFromSettings(ps)
 	d.routing.SplitMode = mode
 	d.routing.SplitApps = apps
+	d.routing.KillSwitch = ps.KillSwitch
 	d.routing = d.routing.Normalize()
-	applySplitToState(&d.state, d.routing)
+	// A stack value from a corrupt or hand-edited file must not reach sing-box;
+	// anything unknown keeps the default.
+	if singbox.ValidStack(ps.TunStack) {
+		d.tun.Stack = ps.TunStack
+	}
+	applySettingsToState(&d.state, d.routing, d.tun)
 	d.mu.Unlock()
 }
 
@@ -193,16 +209,16 @@ func (d *Daemon) SetRuleSetDir(dir string) {
 	d.mu.Unlock()
 }
 
-// persistSettings saves the split portion of ro through the settings store, if
-// one is installed. Persistence is best-effort: a write failure is logged via
-// the daemon's log event but never fails the originating command, mirroring how
-// last-good tolerates a failed write.
-func (d *Daemon) persistSettings(ro routing.Options) {
+// persistSettings saves the user preferences (split, kill switch, tun stack)
+// through the settings store, if one is installed. Persistence is best-effort: a
+// write failure is logged via the daemon's log event but never fails the
+// originating command, mirroring how last-good tolerates a failed write.
+func (d *Daemon) persistSettings(ro routing.Options, tun singbox.TunOptions) {
 	if d.settings == nil {
 		return
 	}
-	if err := d.settings.Save(settingsFromRouting(ro)); err != nil {
-		d.emitLog(LogWarn, fmt.Sprintf("persist split settings: %v", err))
+	if err := d.settings.Save(settingsFrom(ro, tun)); err != nil {
+		d.emitLog(LogWarn, fmt.Sprintf("persist settings: %v", err))
 	}
 }
 
@@ -236,6 +252,10 @@ func (d *Daemon) Handle(ctx context.Context, req Request) Response {
 		return d.handleSetRouting(req)
 	case CmdSetSplit:
 		return d.handleSetSplit(req)
+	case CmdSetKillSwitch:
+		return d.handleSetKillSwitch(req)
+	case CmdSetTun:
+		return d.handleSetTun(req)
 	case CmdLeakCheck:
 		return d.handleLeakCheck(ctx, req)
 	default:
@@ -578,12 +598,13 @@ func (d *Daemon) handleSetSplit(req Request) Response {
 	d.routing.SplitMode = mode
 	d.routing.SplitApps = req.Apps
 	d.routing = d.routing.Normalize()
-	applySplitToState(&d.state, d.routing)
+	applySettingsToState(&d.state, d.routing, d.tun)
 	cur := d.state
 	ro := d.routing
+	tun := d.tun
 	d.mu.Unlock()
 
-	d.persistSettings(ro)
+	d.persistSettings(ro, tun)
 
 	resp, err := newResult(req.ID, cur)
 	if err != nil {
@@ -592,18 +613,78 @@ func (d *Daemon) handleSetSplit(req Request) Response {
 	return resp
 }
 
-// applySplitToState mirrors the normalized split config onto a State. Off
+// handleSetKillSwitch arms or disarms the kill switch. The choice is recorded,
+// persisted, and — unlike set_routing/set_split — applied to a live tunnel in
+// place: the daemon rebuilds the config for the node it is already on and
+// hot-swaps the sing-box process (see reapplyLive), so arming doesn't wait for
+// the user to reconnect. Armed means strict_route on the tun (sing-box installs
+// filter rules that drop any packet trying to escape the tunnel) plus an
+// automatic relaunch if the tunnel process itself dies (see watchProcess).
+func (d *Daemon) handleSetKillSwitch(req Request) Response {
+	d.mu.Lock()
+	changed := d.routing.KillSwitch != req.On
+	d.routing.KillSwitch = req.On
+	applySettingsToState(&d.state, d.routing, d.tun)
+	ro := d.routing
+	tun := d.tun
+	d.mu.Unlock()
+
+	d.persistSettings(ro, tun)
+	if changed {
+		d.reapplyLive()
+	}
+
+	resp, err := newResult(req.ID, d.snapshotState())
+	if err != nil {
+		return newError(req.ID, err.Error())
+	}
+	return resp
+}
+
+// handleSetTun switches the tun network stack (system/gvisor/mixed). Recorded,
+// persisted, and applied to a live tunnel in place via reapplyLive — the stack
+// is a startup option of the tun inbound, so the swap restarts sing-box on the
+// same node rather than walking the whole fallback order again.
+func (d *Daemon) handleSetTun(req Request) Response {
+	if !singbox.ValidStack(req.Stack) {
+		return newError(req.ID, fmt.Sprintf("set_tun: unknown stack %q", req.Stack))
+	}
+
+	d.mu.Lock()
+	changed := d.tun.Stack != req.Stack
+	d.tun.Stack = req.Stack
+	applySettingsToState(&d.state, d.routing, d.tun)
+	ro := d.routing
+	tun := d.tun
+	d.mu.Unlock()
+
+	d.persistSettings(ro, tun)
+	if changed {
+		d.reapplyLive()
+	}
+
+	resp, err := newResult(req.ID, d.snapshotState())
+	if err != nil {
+		return newError(req.ID, err.Error())
+	}
+	return resp
+}
+
+// applySettingsToState mirrors the daemon-wide preferences onto a State: the
+// normalized split config, the kill switch, and the tun stack. Split off
 // collapses to empty fields so the wire form omits them, keeping a no-op split
-// invisible to the UI. The app slice is copied so the State never aliases the
+// invisible to the UI; the app slice is copied so the State never aliases the
 // daemon's live routing options.
-func applySplitToState(s *State, ro routing.Options) {
+func applySettingsToState(s *State, ro routing.Options, tun singbox.TunOptions) {
 	if ro.SplitMode == routing.SplitOff || len(ro.SplitApps) == 0 {
 		s.Split = ""
 		s.SplitApps = nil
-		return
+	} else {
+		s.Split = string(ro.SplitMode)
+		s.SplitApps = append([]string(nil), ro.SplitApps...)
 	}
-	s.Split = string(ro.SplitMode)
-	s.SplitApps = append([]string(nil), ro.SplitApps...)
+	s.KillSwitch = ro.KillSwitch
+	s.TunStack = tun.Stack
 }
 
 // handlePing measures dial latency to every server in a profile and returns the

--- a/core/control/killswitch_tun_test.go
+++ b/core/control/killswitch_tun_test.go
@@ -1,9 +1,11 @@
 package control
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -309,8 +311,10 @@ func TestKillSwitchRelaunchBudget(t *testing.T) {
 		h.runner.exit(errors.New("boom"))
 		h.awaitState(StateConnected) // each death within budget is answered
 	}
+	// Back-to-back deaths never clear the reset window, so the budget still runs
+	// out and the daemon gives up (see the honest wording in killSwitchRelaunch).
 	h.runner.exit(errors.New("boom"))
-	h.awaitLogContains("giving up on restarts")
+	h.awaitLogContains("giving up on automatic restarts")
 	h.awaitState(StateError)
 	if got, want := h.runner.starts(), 1+maxRelaunches; got != want {
 		t.Errorf("starts = %d, want %d (initial + budgeted relaunches)", got, want)
@@ -405,5 +409,259 @@ func TestKillSwitchAndTunPersistAcrossRestart(t *testing.T) {
 	h3.daemon.SetSettings(st3)
 	if got := h3.daemon.snapshotState().TunStack; got != "system" {
 		t.Errorf("tun stack = %q, want the system default for a bogus persisted value", got)
+	}
+}
+
+// waitFor polls cond until it is true, failing the test after 3s. It backs the
+// assertions that watch an asynchronous relaunch/reconcile settle.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", what)
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+}
+
+// TestSetKillSwitchDuringConnectingReconciles: a set_kill_switch that lands while
+// a connect is still in its warmup+probe window is applied to the tunnel that
+// comes up, not merely recorded. The fallback loop pins its options snapshot at
+// the start of the connect, so without the connecting-window reconcile the live
+// tunnel would run without strict_route while the state reports armed — core and
+// UI would disagree with the wire. The reconcile hot-swaps once the connect
+// settles, so the final live config carries strict_route and the reported state
+// matches reality.
+func TestSetKillSwitchDuringConnectingReconciles(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	// Park the first connect inside its probe so the toggle below is guaranteed to
+	// land while the state is still "connecting" (its config already built without
+	// strict_route). Later probes — including the reconcile's — run unblocked.
+	release := make(chan struct{})
+	probing := make(chan struct{}, 1)
+	h.runner.onProbe = func(_ context.Context, n int) {
+		if n != 1 {
+			return
+		}
+		select {
+		case probing <- struct{}{}:
+		default:
+		}
+		<-release
+	}
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnecting)
+	<-probing // first connect is inside its probe; config[0] is built (no strict_route)
+
+	// Arm the kill switch mid-connect. reapplyLive no-ops while connecting, so this
+	// is only recorded here — the reconcile must be what applies it live.
+	h.send(Request{ID: 2, Cmd: CmdSetKillSwitch, On: true})
+	var armed State
+	h.dataInto(h.await(), &armed)
+	if !armed.KillSwitch {
+		t.Fatal("set_kill_switch response kill_switch = false, want true")
+	}
+
+	close(release) // let the first connect finish; the reconcile then hot-swaps
+
+	// The reconcile starts a second process, pinned to the same node; its config
+	// must carry the strict_route the toggle asked for.
+	h.waitStarts(2)
+	cfgs := h.runner.startCfgs()
+	if strict, _ := tunFromConfig(t, cfgs[0]); strict {
+		t.Error("first (connecting-window) config already had strict_route")
+	}
+	if strict, _ := tunFromConfig(t, cfgs[len(cfgs)-1]); !strict {
+		t.Error("reconciled config lacks strict_route; the mid-connect toggle was not applied to the live tunnel")
+	}
+	if connectedNodeTag(t, cfgs[0]) != connectedNodeTag(t, cfgs[len(cfgs)-1]) {
+		t.Error("reconcile moved the selector; it must pin the node that came up")
+	}
+
+	// The live state settles back to connected and genuinely armed — report and
+	// reality now agree.
+	waitFor(t, func() bool {
+		st := h.daemon.snapshotState()
+		return st.State == StateConnected && st.KillSwitch && h.runner.starts() == 2
+	}, "reconcile to settle connected and armed")
+}
+
+// TestKillSwitchDisconnectBeatsRelaunch: an explicit disconnect that lands while a
+// kill-switch relaunch is in flight wins — the tunnel must not come back after the
+// user asked for it to be down. The relaunch goroutine is parked at its entry so
+// the disconnect deterministically claims connMu first; when the relaunch resumes
+// it finds the generation moved and yields instead of resurrecting the tunnel.
+func TestKillSwitchDisconnectBeatsRelaunch(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	relaunching := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	h.daemon.beforeReconnect = func() {
+		once.Do(func() { close(relaunching) })
+		<-release
+	}
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	h.await()
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+	h.waitStarts(1)
+
+	// The process dies with the switch armed: a relaunch is spawned, then parks.
+	h.runner.exit(errors.New("boom"))
+	h.awaitLogContains("kill switch: tunnel process died")
+	<-relaunching
+	startsBefore := h.runner.starts()
+
+	// The user disconnects while the relaunch is parked.
+	h.send(Request{ID: 3, Cmd: CmdDisconnect})
+	var st State
+	h.dataInto(h.await(), &st)
+	if st.State != StateIdle {
+		t.Fatalf("disconnect state = %q, want idle", st.State)
+	}
+	h.awaitState(StateIdle)
+
+	// Release the relaunch: it must observe the bumped generation and abort, not
+	// start a tunnel back up.
+	close(release)
+	time.Sleep(50 * time.Millisecond) // give the goroutine a chance to (wrongly) act
+	if got := h.runner.starts(); got != startsBefore {
+		t.Errorf("relaunch started a tunnel after disconnect (starts %d -> %d); disconnect must win", startsBefore, got)
+	}
+	if got := h.daemon.snapshotState().State; got != StateIdle {
+		t.Errorf("state after disconnect+relaunch = %q, want idle (the tunnel must not resurrect)", got)
+	}
+}
+
+// TestKillSwitchCloseWaitsForRelaunch: Close must not let a kill-switch relaunch
+// outlive the daemon and leak a sing-box process. With the relaunch parked in
+// flight, Close blocks until it unwinds; the relaunch then observes the
+// generation Close bumped and aborts without starting anything, and every started
+// process has been stopped.
+func TestKillSwitchCloseWaitsForRelaunch(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	relaunching := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	h.daemon.beforeReconnect = func() {
+		once.Do(func() { close(relaunching) })
+		<-release
+	}
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	h.await()
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+	h.waitStarts(1)
+
+	h.runner.exit(errors.New("boom"))
+	h.awaitLogContains("kill switch: tunnel process died")
+	<-relaunching // relaunch parked at its gate, tracked so Close waits for it
+	startsBefore := h.runner.starts()
+
+	// Close must block while the relaunch goroutine is still in flight.
+	closed := make(chan error, 1)
+	go func() { closed <- h.daemon.Close() }()
+	select {
+	case <-closed:
+		t.Fatal("Close returned while an in-flight relaunch was still parked")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Release it: on the generation Close bumped, it aborts without starting a
+	// tunnel, and Close then returns.
+	close(release)
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close did not return after the relaunch unwound; the goroutine leaked")
+	}
+
+	if got := h.runner.starts(); got != startsBefore {
+		t.Errorf("relaunch started a tunnel across Close (starts %d -> %d)", startsBefore, got)
+	}
+	if stops, starts := h.runner.stops(), h.runner.starts(); stops < starts {
+		t.Errorf("stops(%d) < starts(%d): a sing-box process leaked past Close", stops, starts)
+	}
+}
+
+// TestKillSwitchRelaunchBudgetRefundedByUptime: a tunnel that keeps dropping but
+// stays connected past the reset window between drops is not a crash-loop, so the
+// relaunch budget is refunded each time and never runs out — even across far more
+// deaths than maxRelaunches. Without the time-gated refund the sixth death would
+// degrade to error and stop auto-restarting. A fake clock supplies the uptime.
+func TestKillSwitchRelaunchBudgetRefundedByUptime(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	var clkMu sync.Mutex
+	now := time.Unix(1_000_000, 0)
+	h.daemon.now = func() time.Time { clkMu.Lock(); defer clkMu.Unlock(); return now }
+	advance := func(d time.Duration) { clkMu.Lock(); now = now.Add(d); clkMu.Unlock() }
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	h.await()
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	// Far more deaths than the budget. Each current tunnel has been up well past
+	// the reset window before it dies (we jump the clock forward first), so every
+	// death reads as a recovery and refunds the budget rather than spending it.
+	for i := 0; i < maxRelaunches+3; i++ {
+		advance(2 * defaultRelaunchReset)
+		h.runner.exit(errors.New("boom"))
+		h.awaitState(StateConnected) // relaunched, not degraded to error
+	}
+}
+
+// TestKillSwitchRelaunchProfileGoneErrors: if the connected profile has vanished
+// from the store by the time its process dies, the armed relaunch can't rebuild a
+// config, so it gives up honestly — logging the reason and degrading to error
+// rather than silently leaving the tunnel down while claiming to be armed.
+func TestKillSwitchRelaunchProfileGoneErrors(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	h.await()
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+	h.waitStarts(1)
+
+	// Drop the profile straight from the store — not via remove_profile, which
+	// would tear the tunnel down first — so the relaunch's own lookup is what fails.
+	if err := h.store.Remove(p.ID); err != nil {
+		t.Fatalf("remove profile: %v", err)
+	}
+
+	h.runner.exit(errors.New("boom"))
+	h.awaitLogContains("cannot restart, profile no longer stored")
+	errState := h.awaitState(StateError)
+	if errState["error"] == nil || errState["error"] == "" {
+		t.Errorf("error state missing message: %+v", errState)
+	}
+	if got := h.runner.starts(); got != 1 {
+		t.Errorf("starts = %d, want 1 (no relaunch when the profile is gone)", got)
 	}
 }

--- a/core/control/killswitch_tun_test.go
+++ b/core/control/killswitch_tun_test.go
@@ -1,0 +1,409 @@
+package control
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Divaaaan/tenebra/core/singbox"
+)
+
+// These tests cover the kill switch and the tun-stack option end to end at the
+// protocol level: recording and reporting the choices, arming strict_route in
+// the built config, hot-swapping a live tunnel in place (same node, no fallback
+// walk), relaunching a tunnel whose process died while the switch was armed,
+// and persisting both preferences across a daemon restart.
+
+// tunFromConfig extracts strict_route and the stack from the (single) tun
+// inbound of a built config.
+func tunFromConfig(t *testing.T, cfgJSON []byte) (strictRoute bool, stack string) {
+	t.Helper()
+	var cfg struct {
+		Inbounds []map[string]any `json:"inbounds"`
+	}
+	if err := json.Unmarshal(cfgJSON, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	for _, in := range cfg.Inbounds {
+		if in["type"] == "tun" {
+			sr, _ := in["strict_route"].(bool)
+			st, _ := in["stack"].(string)
+			return sr, st
+		}
+	}
+	t.Fatal("no tun inbound in config")
+	return false, ""
+}
+
+// awaitLogContains drains log events until one carries the substring.
+func (h *harness) awaitLogContains(sub string) {
+	h.t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case ev := <-h.events:
+			if ev["event"] != EventLog {
+				continue
+			}
+			if msg, _ := ev["msg"].(string); strings.Contains(msg, sub) {
+				return
+			}
+		case <-deadline:
+			h.t.Fatalf("timed out waiting for log containing %q", sub)
+		}
+	}
+}
+
+// TestSetKillSwitchIdleAppliesOnNextConnect: arming while idle is recorded,
+// reported, and lands as strict_route in the next connect's config.
+func TestSetKillSwitchIdleAppliesOnNextConnect(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	var st State
+	h.dataInto(h.await(), &st)
+	if !st.KillSwitch {
+		t.Fatalf("set_kill_switch response kill_switch = false, want true")
+	}
+	if h.runner.starts() != 0 {
+		t.Fatalf("arming while idle started a process (starts=%d)", h.runner.starts())
+	}
+
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	strict, _ := tunFromConfig(t, h.runner.startCfgs()[0])
+	if !strict {
+		t.Error("config built with kill switch armed lacks strict_route")
+	}
+}
+
+// TestKillSwitchDefaultsOff: without arming, the built config must not carry
+// strict_route — the rough-connect trade-off is strictly opt-in.
+func TestKillSwitchDefaultsOff(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	strict, stack := tunFromConfig(t, h.runner.startCfgs()[0])
+	if strict {
+		t.Error("strict_route on by default; the kill switch must be opt-in")
+	}
+	if stack != "system" {
+		t.Errorf("default stack = %q, want system", stack)
+	}
+}
+
+// TestSetKillSwitchLiveHotSwapsSameNode: arming while connected restarts
+// sing-box once, pinned to the node already in use, and comes back connected
+// with strict_route in the new config.
+func TestSetKillSwitchLiveHotSwapsSameNode(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	connected := h.awaitState(StateConnected)
+	node := connected["node"].(string)
+
+	h.send(Request{ID: 2, Cmd: CmdSetKillSwitch, On: true})
+	var st State
+	h.dataInto(h.await(), &st)
+	if !st.KillSwitch {
+		t.Fatal("response kill_switch = false, want true")
+	}
+
+	// The swap dips through connecting and lands connected on the same node.
+	re := h.awaitState(StateConnected)
+	if re["node"] != node {
+		t.Errorf("reconnected node = %v, want the same node %s", re["node"], node)
+	}
+
+	cfgs := h.runner.startCfgs()
+	if len(cfgs) != 2 {
+		t.Fatalf("starts = %d, want 2 (one connect, one hot swap)", len(cfgs))
+	}
+	if strict, _ := tunFromConfig(t, cfgs[0]); strict {
+		t.Error("initial config already had strict_route")
+	}
+	if strict, _ := tunFromConfig(t, cfgs[1]); !strict {
+		t.Error("hot-swapped config lacks strict_route")
+	}
+	if tagBefore, tagAfter := connectedNodeTag(t, cfgs[0]), connectedNodeTag(t, cfgs[1]); tagBefore != tagAfter {
+		t.Errorf("hot swap moved the selector: %q -> %q; it must pin the current node", tagBefore, tagAfter)
+	}
+}
+
+// TestSetKillSwitchUnchangedDoesNotRestart: re-sending the current value must
+// not bounce a live tunnel.
+func TestSetKillSwitchUnchangedDoesNotRestart(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	h.send(Request{ID: 2, Cmd: CmdSetKillSwitch, On: false}) // already off
+	h.await()
+	if h.runner.starts() != 1 {
+		t.Errorf("starts = %d, want 1 (no-op toggle must not restart)", h.runner.starts())
+	}
+}
+
+// TestSetTunRejectsUnknownStack: the stack is validated before anything is
+// recorded, so junk can never reach sing-box.
+func TestSetTunRejectsUnknownStack(t *testing.T) {
+	h := newHarness(t)
+
+	h.send(Request{ID: 1, Cmd: CmdSetTun, Stack: "warp-drive"})
+	r := h.await()
+	if r.Ok {
+		t.Fatal("set_tun accepted an unknown stack")
+	}
+	if !strings.Contains(r.Error, "unknown stack") {
+		t.Errorf("error = %q, want it to name the unknown stack", r.Error)
+	}
+}
+
+// TestSetTunIdleAppliesOnNextConnect: a stack chosen while idle is reported in
+// the state and used by the next connect's config.
+func TestSetTunIdleAppliesOnNextConnect(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdSetTun, Stack: singbox.StackGvisor})
+	var st State
+	h.dataInto(h.await(), &st)
+	if st.TunStack != "gvisor" {
+		t.Fatalf("tun_stack = %q, want gvisor", st.TunStack)
+	}
+
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	if _, stack := tunFromConfig(t, h.runner.startCfgs()[0]); stack != "gvisor" {
+		t.Errorf("config stack = %q, want gvisor", stack)
+	}
+}
+
+// TestSetTunLiveHotSwapsSameNode: switching the stack under a live tunnel
+// restarts once on the same node with the new stack.
+func TestSetTunLiveHotSwapsSameNode(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	connected := h.awaitState(StateConnected)
+
+	h.send(Request{ID: 2, Cmd: CmdSetTun, Stack: singbox.StackMixed})
+	h.await()
+	re := h.awaitState(StateConnected)
+	if re["node"] != connected["node"] {
+		t.Errorf("reconnected node = %v, want %v", re["node"], connected["node"])
+	}
+
+	cfgs := h.runner.startCfgs()
+	if len(cfgs) != 2 {
+		t.Fatalf("starts = %d, want 2", len(cfgs))
+	}
+	if _, stack := tunFromConfig(t, cfgs[1]); stack != "mixed" {
+		t.Errorf("hot-swapped config stack = %q, want mixed", stack)
+	}
+	if connectedNodeTag(t, cfgs[0]) != connectedNodeTag(t, cfgs[1]) {
+		t.Error("hot swap moved the selector; it must pin the current node")
+	}
+}
+
+// TestSetTunSameStackDoesNotRestart: choosing the stack already in effect is a
+// no-op for a live tunnel.
+func TestSetTunSameStackDoesNotRestart(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	h.send(Request{ID: 2, Cmd: CmdSetTun, Stack: singbox.StackSystem})
+	h.await()
+	if h.runner.starts() != 1 {
+		t.Errorf("starts = %d, want 1 (same stack must not restart)", h.runner.starts())
+	}
+}
+
+// TestKillSwitchRelaunchesDeadTunnel: with the switch armed, an unexpected
+// process exit is answered with a relaunch pinned to the same node, and the
+// state comes back connected rather than error.
+func TestKillSwitchRelaunchesDeadTunnel(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	h.await()
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	connected := h.awaitState(StateConnected)
+
+	h.runner.exit(errors.New("boom"))
+	h.awaitLogContains("kill switch: tunnel process died")
+	re := h.awaitState(StateConnected)
+	if re["node"] != connected["node"] {
+		t.Errorf("relaunched node = %v, want %v", re["node"], connected["node"])
+	}
+
+	cfgs := h.runner.startCfgs()
+	if len(cfgs) != 2 {
+		t.Fatalf("starts = %d, want 2 (connect + relaunch)", len(cfgs))
+	}
+	if strict, _ := tunFromConfig(t, cfgs[1]); !strict {
+		t.Error("relaunched config lacks strict_route")
+	}
+	if connectedNodeTag(t, cfgs[0]) != connectedNodeTag(t, cfgs[1]) {
+		t.Error("relaunch moved the selector; it must pin the node that was up")
+	}
+}
+
+// TestNoRelaunchWhenDisarmed: without the kill switch, a process death remains
+// a plain error state — the pre-kill-switch behaviour.
+func TestNoRelaunchWhenDisarmed(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	h.runner.exit(errors.New("boom"))
+	errState := h.awaitState(StateError)
+	if errState["error"] != "boom" {
+		t.Errorf("error = %v, want boom", errState["error"])
+	}
+	if h.runner.starts() != 1 {
+		t.Errorf("starts = %d, want 1 (no relaunch when disarmed)", h.runner.starts())
+	}
+}
+
+// TestKillSwitchRelaunchBudget: a tunnel that keeps dying gets maxRelaunches
+// restarts and then an error state; an explicit reconnect opens a fresh budget.
+func TestKillSwitchRelaunchBudget(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	h.await()
+	h.send(Request{ID: 2, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+
+	for i := 0; i < maxRelaunches; i++ {
+		h.runner.exit(errors.New("boom"))
+		h.awaitState(StateConnected) // each death within budget is answered
+	}
+	h.runner.exit(errors.New("boom"))
+	h.awaitLogContains("giving up on restarts")
+	h.awaitState(StateError)
+	if got, want := h.runner.starts(), 1+maxRelaunches; got != want {
+		t.Errorf("starts = %d, want %d (initial + budgeted relaunches)", got, want)
+	}
+
+	// A user reconnect resets the budget: the next death relaunches again.
+	h.send(Request{ID: 3, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+	h.runner.exit(errors.New("boom"))
+	h.awaitState(StateConnected)
+}
+
+// TestReapplyDefersWhenNodeVanished: if the connected node is gone from the
+// store by the time a setting changes, the live tunnel is left running on the
+// old options and the change is logged as deferred — never a torn-down tunnel
+// with nothing to replace it.
+func TestReapplyDefersWhenNodeVanished(t *testing.T) {
+	h := newHarness(t)
+	p := seedMultiProto(t, h)
+
+	h.send(Request{ID: 1, Cmd: CmdConnect, Profile: p.ID})
+	h.await()
+	h.awaitState(StateConnected)
+	// Connect's own teardown always issues one (idempotent) Stop before
+	// starting; everything after this baseline must leave the runner alone.
+	stopsAfterConnect := h.runner.stops()
+
+	// Drop the connected node (the walk lands on the first, vless-id).
+	p.Servers = p.Servers[1:]
+	if err := h.store.Update(p); err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+
+	h.send(Request{ID: 2, Cmd: CmdSetKillSwitch, On: true})
+	var st State
+	h.dataInto(h.await(), &st)
+	if !st.KillSwitch {
+		t.Fatal("kill switch not recorded when the re-apply is deferred")
+	}
+	h.awaitLogContains("re-apply")
+	if h.runner.starts() != 1 {
+		t.Errorf("starts = %d, want 1 (deferred re-apply must not restart)", h.runner.starts())
+	}
+	if got := h.runner.stops(); got != stopsAfterConnect {
+		t.Errorf("stops = %d, want %d (the live tunnel must be left alone)", got, stopsAfterConnect)
+	}
+}
+
+// TestKillSwitchAndTunPersistAcrossRestart: both preferences round-trip through
+// the settings file and load into a fresh daemon's state; a corrupt stack value
+// falls back to the default instead of reaching sing-box.
+func TestKillSwitchAndTunPersistAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	h := newHarness(t)
+	st, err := OpenFileSettings(dir)
+	if err != nil {
+		t.Fatalf("open settings: %v", err)
+	}
+	h.daemon.SetSettings(st)
+
+	h.send(Request{ID: 1, Cmd: CmdSetKillSwitch, On: true})
+	h.await()
+	h.send(Request{ID: 2, Cmd: CmdSetTun, Stack: singbox.StackGvisor})
+	h.await()
+
+	// A "restarted" daemon over the same directory loads both back.
+	h2 := newHarness(t)
+	st2, err := OpenFileSettings(dir)
+	if err != nil {
+		t.Fatalf("reopen settings: %v", err)
+	}
+	h2.daemon.SetSettings(st2)
+	loaded := h2.daemon.snapshotState()
+	if !loaded.KillSwitch {
+		t.Error("kill switch did not survive the restart")
+	}
+	if loaded.TunStack != "gvisor" {
+		t.Errorf("tun stack = %q, want gvisor after restart", loaded.TunStack)
+	}
+
+	// A hand-edited stack the builder doesn't know keeps the default.
+	if err := st2.Save(persistedSettings{TunStack: "bogus", KillSwitch: true}); err != nil {
+		t.Fatalf("save bogus settings: %v", err)
+	}
+	h3 := newHarness(t)
+	st3, err := OpenFileSettings(dir)
+	if err != nil {
+		t.Fatalf("reopen settings: %v", err)
+	}
+	h3.daemon.SetSettings(st3)
+	if got := h3.daemon.snapshotState().TunStack; got != "system" {
+		t.Errorf("tun stack = %q, want the system default for a bogus persisted value", got)
+	}
+}

--- a/core/control/protocol.go
+++ b/core/control/protocol.go
@@ -35,6 +35,8 @@ const (
 	CmdPing               = "ping"
 	CmdSetRouting         = "set_routing"
 	CmdSetSplit           = "set_split"
+	CmdSetKillSwitch      = "set_kill_switch"
+	CmdSetTun             = "set_tun"
 	CmdLeakCheck          = "leak_check"
 )
 
@@ -98,6 +100,12 @@ type Request struct {
 	Mode string `json:"mode,omitempty"`
 	// Apps is the executable-name list for set_split, e.g. ["chrome.exe"].
 	Apps []string `json:"apps,omitempty"`
+	// On arms (true) or disarms (false) the kill switch for set_kill_switch. An
+	// omitted field decodes to false, so "disarm" and "field left out" coincide —
+	// which is the safe reading for a command that grants, not removes, blocking.
+	On bool `json:"on,omitempty"`
+	// Stack is the tun network stack for set_tun (system/gvisor/mixed).
+	Stack string `json:"stack,omitempty"`
 }
 
 // Response is a core -> UI reply to a Request, correlated by ID. Exactly one of
@@ -131,7 +139,14 @@ type State struct {
 	// connect will use; an empty/off split omits them.
 	Split     string   `json:"split,omitempty"`
 	SplitApps []string `json:"split_apps,omitempty"`
-	Error     string   `json:"error,omitempty"`
+	// KillSwitch reports whether the kill switch is armed (strict_route on the
+	// tun, plus an automatic relaunch if the tunnel process dies). Omitted when
+	// off, like the split fields.
+	KillSwitch bool `json:"kill_switch,omitempty"`
+	// TunStack is the tun network stack (system/gvisor/mixed) the current or
+	// next tunnel uses. Always present once the daemon has normalized it.
+	TunStack string `json:"tun_stack,omitempty"`
+	Error    string `json:"error,omitempty"`
 }
 
 // PingResult is one node's dial-latency probe outcome.

--- a/core/control/settings_file.go
+++ b/core/control/settings_file.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/Divaaaan/tenebra/core/routing"
+	"github.com/Divaaaan/tenebra/core/singbox"
 )
 
 // settingsFile is the name of the JSON file persisting user routing preferences
@@ -17,10 +18,11 @@ import (
 // so they survive a restart.
 const settingsFile = "settings.json"
 
-// persistedSettings is the on-disk shape. Only the split configuration is stored
-// today; the struct is versioned so new preference fields can be added without a
-// migration. A field added later defaults to its zero value when reading an old
-// file, which Normalize then turns into the sane default.
+// persistedSettings is the on-disk shape: the split configuration, the kill
+// switch, and the tun stack. The struct is versioned so new preference fields
+// can be added without a migration. A field added later defaults to its zero
+// value when reading an old file, which the loading path then turns into the
+// sane default.
 type persistedSettings struct {
 	// Version guards the format. Bump it only on an incompatible change; readers
 	// of an unknown future version fall back to defaults rather than guessing.
@@ -28,6 +30,14 @@ type persistedSettings struct {
 
 	SplitMode string   `json:"split_mode,omitempty"`
 	SplitApps []string `json:"split_apps,omitempty"`
+
+	// KillSwitch remembers whether the user armed the kill switch. Absent in
+	// files written before the field existed, which reads back as false — off,
+	// matching the pre-kill-switch behaviour.
+	KillSwitch bool `json:"kill_switch,omitempty"`
+	// TunStack remembers the chosen tun network stack (system/gvisor/mixed).
+	// Absent or unrecognized keeps the default; SetSettings validates it.
+	TunStack string `json:"tun_stack,omitempty"`
 }
 
 // settingsVersion is the current persisted-settings format version.
@@ -139,13 +149,15 @@ func splitFromSettings(ps persistedSettings) (routing.SplitMode, []string) {
 	return o.SplitMode, o.SplitApps
 }
 
-// settingsFromRouting projects the split portion of routing options into the
-// persisted shape.
-func settingsFromRouting(ro routing.Options) persistedSettings {
+// settingsFrom projects the persisted preferences out of the live routing and
+// tun options.
+func settingsFrom(ro routing.Options, tun singbox.TunOptions) persistedSettings {
 	return persistedSettings{
-		Version:   settingsVersion,
-		SplitMode: string(ro.SplitMode),
-		SplitApps: ro.SplitApps,
+		Version:    settingsVersion,
+		SplitMode:  string(ro.SplitMode),
+		SplitApps:  ro.SplitApps,
+		KillSwitch: ro.KillSwitch,
+		TunStack:   tun.Stack,
 	}
 }
 

--- a/core/control/split_control_test.go
+++ b/core/control/split_control_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Divaaaan/tenebra/core/routing"
+	"github.com/Divaaaan/tenebra/core/singbox"
 )
 
 // TestSetSplitExclude: a set_split exclude request is accepted, echoes the
@@ -112,24 +113,35 @@ func TestSetSplitDoesNotDisturbRoutingMode(t *testing.T) {
 	}
 }
 
-// TestApplySplitToState verifies the State projection directly.
-func TestApplySplitToState(t *testing.T) {
+// TestApplySettingsToState verifies the State projection directly.
+func TestApplySettingsToState(t *testing.T) {
+	tun := singbox.TunOptions{Stack: singbox.StackSystem}
+
 	var s State
-	applySplitToState(&s, routing.Options{SplitMode: routing.SplitInclude, SplitApps: []string{"a.exe"}}.Normalize())
+	applySettingsToState(&s, routing.Options{SplitMode: routing.SplitInclude, SplitApps: []string{"a.exe"}}.Normalize(), tun)
 	if s.Split != "include" || !reflect.DeepEqual(s.SplitApps, []string{"a.exe"}) {
 		t.Errorf("apply include = %q %v", s.Split, s.SplitApps)
 	}
+	if s.TunStack != "system" {
+		t.Errorf("tun stack = %q, want system", s.TunStack)
+	}
 	// Off clears prior values.
-	applySplitToState(&s, routing.Options{SplitMode: routing.SplitOff}.Normalize())
+	applySettingsToState(&s, routing.Options{SplitMode: routing.SplitOff}.Normalize(), tun)
 	if s.Split != "" || s.SplitApps != nil {
 		t.Errorf("apply off should clear, got %q %v", s.Split, s.SplitApps)
 	}
 	// The stored slice must not alias the routing options.
 	ro := routing.Options{SplitMode: routing.SplitExclude, SplitApps: []string{"x.exe", "y.exe"}}.Normalize()
-	applySplitToState(&s, ro)
+	applySettingsToState(&s, ro, tun)
 	ro.SplitApps[0] = "MUTATED"
 	if s.SplitApps[0] == "MUTATED" {
 		t.Error("State.SplitApps aliases the routing options slice")
+	}
+	// The kill switch and a non-default stack project through as-is.
+	ro.KillSwitch = true
+	applySettingsToState(&s, ro, singbox.TunOptions{Stack: singbox.StackGvisor})
+	if !s.KillSwitch || s.TunStack != "gvisor" {
+		t.Errorf("kill_switch/tun_stack = %v %q, want true gvisor", s.KillSwitch, s.TunStack)
 	}
 }
 

--- a/core/singbox/builder.go
+++ b/core/singbox/builder.go
@@ -17,7 +17,7 @@ import (
 const (
 	defaultInterfaceName = "tenebra"
 	defaultMTU           = 9000
-	defaultStack         = "system"
+	defaultStack         = StackSystem
 	defaultClashAPIPort  = 9090
 
 	tunTag    = "tun-in"
@@ -26,6 +26,27 @@ const (
 	directTag = "direct"
 	blockTag  = "block"
 )
+
+// The tun stacks sing-box implements. system uses the kernel's own TCP/IP
+// (fastest, needs the tun driver to behave); gvisor runs a userspace stack
+// (slower, but immune to driver quirks); mixed splits TCP onto system and UDP
+// onto gvisor.
+const (
+	StackSystem = "system"
+	StackGvisor = "gvisor"
+	StackMixed  = "mixed"
+)
+
+// ValidStack reports whether s names a tun stack sing-box accepts. The empty
+// string is not valid here — callers that mean "default" should leave the
+// option unset and let normalize fill it.
+func ValidStack(s string) bool {
+	switch s {
+	case StackSystem, StackGvisor, StackMixed:
+		return true
+	}
+	return false
+}
 
 // TunOptions configures the single tun inbound and the clash API. The zero
 // value is filled with defaults by Build.

--- a/docs/control-protocol.md
+++ b/docs/control-protocol.md
@@ -113,9 +113,12 @@ means two things:
 - if the **tunnel process itself dies**, the core relaunches it immediately,
   pinned to the node that was up — strict_route only holds while sing-box runs,
   so putting the process (and its filter rules) back is the only honest
-  mitigation. Relaunches are budgeted (5 in a row, reset by an explicit
-  connect/disconnect) so a tunnel that dies on every start can't churn forever;
-  past the budget the state degrades to `error` like any dropped tunnel.
+  mitigation. Relaunches are budgeted (up to 5 for a tunnel caught in a
+  crash-loop) so one that dies on every start can't churn forever; past the
+  budget the state degrades to `error` like any dropped tunnel. The budget counts
+  only rapid, back-to-back deaths: it resets on an explicit connect/disconnect,
+  and a relaunched tunnel that then stays connected for a while refunds it, so
+  isolated drops across a long session never accumulate toward the cap.
 
 Be honest with users about the limits: **while the process is down — the gap
 before a relaunch lands, or after the budget is spent — the OS routes normally

--- a/docs/control-protocol.md
+++ b/docs/control-protocol.md
@@ -30,6 +30,8 @@ Three message kinds flow over the link:
 | `ping`                 | `profile`                          | `{ results: PingResult[] }` |
 | `set_routing`          | `mode` (`smart`/`global`/`direct`) | `State`                     |
 | `set_split`            | `mode` (`off`/`exclude`/`include`), `apps?` | `State`            |
+| `set_kill_switch`      | `on` (boolean)                     | `State`                     |
+| `set_tun`              | `stack` (`system`/`gvisor`/`mixed`) | `State`                    |
 | `leak_check`           | —                                  | `LeakCheck`                 |
 
 ```
@@ -93,6 +95,67 @@ response: {"id":7,"ok":true,"data":{"profile":{ /* …two servers… */ },"impor
 `set_routing` and `set_split` only record the choice; like a routing change, a
 new split takes effect on the **next connect** (live retuning would require
 restarting sing-box). The returned `State` reflects the stored choice.
+
+`set_kill_switch` and `set_tun` go further: both are recorded and persisted the
+same way, but when a tunnel is **live** the core also re-applies them in place —
+see below.
+
+### Kill switch (`set_kill_switch`)
+
+`on: true` arms the kill switch; `false` (or an omitted field) disarms it. Armed
+means two things:
+
+- the tun inbound is built with **`strict_route`**: sing-box installs firewall
+  rules that drop any packet trying to route around the tunnel, so a dead
+  upstream node black-holes traffic instead of leaking it onto the physical
+  interface. The trade-off is a rougher connect (the rules are applied
+  system-wide the moment the tunnel comes up), which is why this is opt-in;
+- if the **tunnel process itself dies**, the core relaunches it immediately,
+  pinned to the node that was up — strict_route only holds while sing-box runs,
+  so putting the process (and its filter rules) back is the only honest
+  mitigation. Relaunches are budgeted (5 in a row, reset by an explicit
+  connect/disconnect) so a tunnel that dies on every start can't churn forever;
+  past the budget the state degrades to `error` like any dropped tunnel.
+
+Be honest with users about the limits: **while the process is down — the gap
+before a relaunch lands, or after the budget is spent — the OS routes normally
+and traffic is not blocked.** A guarantee across that window would need an
+OS-level firewall hold owned by something that outlives sing-box; the protocol
+does not promise it.
+
+### Tun stack (`set_tun`)
+
+`stack` selects the tun network stack: `system` (the kernel's own TCP/IP —
+fastest, the default), `gvisor` (a userspace stack — slower, but immune to tun
+driver quirks), or `mixed` (TCP on system, UDP on gvisor). An unknown value is
+an error and nothing is recorded.
+
+### Live re-apply
+
+Both options are startup parameters of the tun inbound — sing-box cannot change
+them on a running process. When either command lands while `connected`, the core
+**hot-swaps** the tunnel: it rebuilds the config for the node it is already on
+and restarts sing-box against it. This is deliberately *not* a full reconnect —
+no fallback walk, no node re-selection, no ping ranking; the candidate set is
+pinned to the current node. The UI sees the ordinary `connecting` → `connected`
+dip while the swap-and-probe runs (typically a second or two); a failed probe
+surfaces as an `error` state exactly like any dropped tunnel.
+
+When nothing is connected, the commands just record the choice for the next
+connect. If the live profile/node has meanwhile disappeared from the store, the
+running tunnel is left untouched and the change is deferred to the next connect
+(a settings toggle must never tear down a working tunnel without bringing one
+back); a `log` event notes the deferral.
+
+Both preferences are **persisted** in `settings.json` alongside the split
+config, and load back into the reported `State` on launch.
+
+```
+request:  {"id":9,"cmd":"set_kill_switch","on":true}
+response: {"id":9,"ok":true,"data":{"state":"connecting","profile":"p1","kill_switch":true,"tun_stack":"system"}}
+request:  {"id":10,"cmd":"set_tun","stack":"gvisor"}
+response: {"id":10,"ok":true,"data":{"state":"idle","tun_stack":"gvisor"}}
+```
 
 ### Per-app split tunnelling (`set_split`)
 
@@ -187,6 +250,8 @@ type State = {
   routing?: "smart" | "global" | "direct";
   split?: "exclude" | "include";  // omitted when off
   split_apps?: string[];          // normalized executable names; omitted when off
+  kill_switch?: boolean;          // omitted when off
+  tun_stack?: "system" | "gvisor" | "mixed";
   error?: string;
 };
 

--- a/ui-desktop/src-tauri/src/backend/mock.rs
+++ b/ui-desktop/src-tauri/src/backend/mock.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 
 use super::{
     Backend, ConnectionState, DnsResult, DnsStatus, EventSink, ExitMatch, ImportLinksResult,
-    LeakCheck, Node, PingResult, Profile, Protocol, RoutingMode, Source, SplitMode, State, Verdict,
+    LeakCheck, Node, PingResult, Profile, Protocol, RoutingMode, Source, SplitMode, State,
+    TunStack, Verdict,
 };
 
 /// How long the fake "dial" takes before flipping to connected.
@@ -60,6 +61,9 @@ impl MockBackend {
                 routing: Some(RoutingMode::Smart),
                 split: None,
                 split_apps: None,
+                kill_switch: None,
+                // The core always names the stack once normalized; mirror that.
+                tun_stack: Some(TunStack::System),
                 error: None,
             },
             profiles: demo_profiles(),
@@ -403,6 +407,29 @@ impl Backend for MockBackend {
             inner.state.split = Some(mode);
             inner.state.split_apps = Some(apps);
         }
+        let snapshot = inner.state.clone();
+        drop(inner);
+        self.shared.emit_state(&snapshot);
+        Ok(snapshot)
+    }
+
+    fn set_kill_switch(&self, on: bool) -> Result<State, String> {
+        // Mirror the core: record and report; a live "tunnel" would hot-swap,
+        // which the mock abbreviates to just the state change.
+        let mut inner = self.shared.inner.lock().unwrap();
+        inner.state.kill_switch = if on { Some(true) } else { None };
+        let snapshot = inner.state.clone();
+        drop(inner);
+        self.shared.emit_state(&snapshot);
+        self.shared
+            .sink
+            .log("info", if on { "kill switch armed" } else { "kill switch disarmed" });
+        Ok(snapshot)
+    }
+
+    fn set_tun(&self, stack: TunStack) -> Result<State, String> {
+        let mut inner = self.shared.inner.lock().unwrap();
+        inner.state.tun_stack = Some(stack);
         let snapshot = inner.state.clone();
         drop(inner);
         self.shared.emit_state(&snapshot);
@@ -917,6 +944,32 @@ mod tests {
         let s = b.set_split(SplitMode::Off, vec!["x.exe".into()]).unwrap();
         assert_eq!(s.split, None);
         assert_eq!(s.split_apps, None);
+    }
+
+    #[test]
+    fn set_kill_switch_arms_and_disarms() {
+        let (b, sink) = backend();
+        let s = b.set_kill_switch(true).unwrap();
+        assert_eq!(s.kill_switch, Some(true));
+        assert_eq!(sink.last_state().unwrap().kill_switch, Some(true));
+
+        // Disarming drops the field entirely (off is reported as absent).
+        let s = b.set_kill_switch(false).unwrap();
+        assert_eq!(s.kill_switch, None);
+    }
+
+    #[test]
+    fn set_tun_updates_the_stack_and_emits() {
+        let (b, sink) = backend();
+        // The mock starts on the default stack, like the core reports it.
+        assert_eq!(b.status().unwrap().tun_stack, Some(TunStack::System));
+
+        let s = b.set_tun(TunStack::Gvisor).unwrap();
+        assert_eq!(s.tun_stack, Some(TunStack::Gvisor));
+        assert_eq!(
+            sink.last_state().unwrap().tun_stack,
+            Some(TunStack::Gvisor)
+        );
     }
 
     #[test]

--- a/ui-desktop/src-tauri/src/backend/mod.rs
+++ b/ui-desktop/src-tauri/src/backend/mod.rs
@@ -50,6 +50,18 @@ pub enum SplitMode {
     Include,
 }
 
+/// The tun network stack sing-box runs. `System` is the kernel's own TCP/IP
+/// (fastest, the default); `Gvisor` is a userspace stack (slower, immune to tun
+/// driver quirks); `Mixed` puts TCP on system and UDP on gvisor. Mirrors the
+/// core's stack tokens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TunStack {
+    System,
+    Gvisor,
+    Mixed,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Protocol {
@@ -83,6 +95,12 @@ pub struct State {
     /// Executable names the split applies to; absent when off.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub split_apps: Option<Vec<String>>,
+    /// Whether the kill switch is armed; absent (treated as off) when it isn't.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kill_switch: Option<bool>,
+    /// The tun network stack the current or next tunnel uses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tun_stack: Option<TunStack>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -260,6 +278,13 @@ pub trait Backend: Send + Sync + 'static {
     fn ping(&self, profile: String) -> Result<Vec<PingResult>, String>;
     fn set_routing(&self, mode: RoutingMode) -> Result<State, String>;
     fn set_split(&self, mode: SplitMode, apps: Vec<String>) -> Result<State, String>;
+    /// Arm or disarm the kill switch. The core persists the choice and, when a
+    /// tunnel is live, re-applies it in place by hot-swapping sing-box on the
+    /// same node (a brief connecting→connected dip, not a full reconnect).
+    fn set_kill_switch(&self, on: bool) -> Result<State, String>;
+    /// Switch the tun network stack. Same live re-apply semantics as the kill
+    /// switch; when idle the choice simply applies on the next connect.
+    fn set_tun(&self, stack: TunStack) -> Result<State, String>;
     fn leak_check(&self) -> Result<LeakCheck, String>;
 }
 
@@ -304,6 +329,13 @@ mod tests {
         assert_token(SplitMode::Off, "off");
         assert_token(SplitMode::Exclude, "exclude");
         assert_token(SplitMode::Include, "include");
+    }
+
+    #[test]
+    fn tun_stack_tokens() {
+        assert_token(TunStack::System, "system");
+        assert_token(TunStack::Gvisor, "gvisor");
+        assert_token(TunStack::Mixed, "mixed");
     }
 
     #[test]
@@ -354,6 +386,8 @@ mod tests {
             routing: Some(RoutingMode::Smart),
             split: Some(SplitMode::Exclude),
             split_apps: Some(vec!["chrome.exe".into(), "steam.exe".into()]),
+            kill_switch: Some(true),
+            tun_stack: Some(TunStack::Gvisor),
             error: None,
         };
         let json = to_value(&state).unwrap();
@@ -370,13 +404,24 @@ mod tests {
             routing: None,
             split: None,
             split_apps: None,
+            kill_switch: None,
+            tun_stack: None,
             error: None,
         };
         let obj = to_value(&state).unwrap();
         let map = obj.as_object().unwrap();
         // Only the always-present discriminant survives.
         assert_eq!(map.get("state"), Some(&json!("idle")));
-        for absent in ["node", "profile", "routing", "split", "split_apps", "error"] {
+        for absent in [
+            "node",
+            "profile",
+            "routing",
+            "split",
+            "split_apps",
+            "kill_switch",
+            "tun_stack",
+            "error",
+        ] {
             assert!(
                 !map.contains_key(absent),
                 "expected {absent} to be omitted, got {obj}"

--- a/ui-desktop/src-tauri/src/backend/sidecar.rs
+++ b/ui-desktop/src-tauri/src/backend/sidecar.rs
@@ -32,7 +32,7 @@ use serde_json::{json, Value};
 
 use super::{
     Backend, EventSink, ImportLinksResult, LeakCheck, PingResult, Profile, RoutingMode, SplitMode,
-    State, EVENT_LOG, EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
+    State, TunStack, EVENT_LOG, EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
 };
 
 /// How long a request waits for its correlated response before giving up. The
@@ -522,6 +522,21 @@ impl Backend for SidecarBackend {
             "set_split",
             obj([("mode", json!(mode)), ("apps", json!(apps))]),
         )
+    }
+
+    fn set_kill_switch(&self, on: bool) -> Result<State, String> {
+        self.inner
+            .request_into("set_kill_switch", obj([("on", json!(on))]))
+    }
+
+    fn set_tun(&self, stack: TunStack) -> Result<State, String> {
+        let stack = match stack {
+            TunStack::System => "system",
+            TunStack::Gvisor => "gvisor",
+            TunStack::Mixed => "mixed",
+        };
+        self.inner
+            .request_into("set_tun", obj([("stack", json!(stack))]))
     }
 
     fn leak_check(&self) -> Result<LeakCheck, String> {

--- a/ui-desktop/src-tauri/src/lib.rs
+++ b/ui-desktop/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ use tauri::{AppHandle, Emitter, Manager, State as TauriState, WindowEvent};
 
 use backend::{
     Backend, ConnectionState, EventSink, ImportLinksResult, LeakCheck, PingResult, Profile,
-    RoutingMode, SplitMode, State, EVENT_LOG, EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
+    RoutingMode, SplitMode, State, TunStack, EVENT_LOG, EVENT_PROFILES, EVENT_STATE, EVENT_TRAFFIC,
 };
 
 /// Held in Tauri's managed state and shared by every command handler. The
@@ -250,6 +250,16 @@ async fn set_split(
 }
 
 #[tauri::command]
+async fn set_kill_switch(state: TauriState<'_, AppState>, on: bool) -> Result<State, String> {
+    off_thread(Arc::clone(&state.backend), move |b| b.set_kill_switch(on)).await
+}
+
+#[tauri::command]
+async fn set_tun(state: TauriState<'_, AppState>, stack: TunStack) -> Result<State, String> {
+    off_thread(Arc::clone(&state.backend), move |b| b.set_tun(stack)).await
+}
+
+#[tauri::command]
 async fn leak_check(state: TauriState<'_, AppState>) -> Result<LeakCheck, String> {
     off_thread(Arc::clone(&state.backend), |b| b.leak_check()).await
 }
@@ -329,6 +339,8 @@ pub fn run() {
             ping,
             set_routing,
             set_split,
+            set_kill_switch,
+            set_tun,
             leak_check,
             quit_app,
         ])

--- a/ui-desktop/src/App.tsx
+++ b/ui-desktop/src/App.tsx
@@ -20,19 +20,11 @@ import { formatMbps } from "./lib/format";
 import {
   getAutoconnect,
   getAutoFastest,
-  getKillSwitch,
   getLastProfileId,
-  setKillSwitch as persistKillSwitch,
   setLastProfileId,
 } from "./lib/settings";
 
 type Overlay = "profiles" | "settings" | "logs" | null;
-
-// The kill-switch UI exists, but the core doesn't yet honour it at connect time
-// (it's a routing option with no control-protocol command). Until that's wired,
-// the toggle is shown disabled and the "armed" banner is suppressed — we never
-// claim a protection we don't actually deliver. Flip this when the wiring lands.
-const KILL_SWITCH_WIRED = false;
 
 export function App() {
   const tenebra = useTenebra();
@@ -48,9 +40,13 @@ export function App() {
   const [selectedNodeId, setSelectedNodeId] = useState("");
   const [region, setRegion] = useState<Region | null>(null);
   const [query, setQuery] = useState("");
-  const [killSwitch, setKillSwitchState] = useState(getKillSwitch);
   const [overlay, setOverlay] = useState<Overlay>(null);
   const [busy, setBusy] = useState(false);
+
+  // The kill switch is core-owned: the daemon persists it, arms strict_route in
+  // the tunnel config, and restarts a tunnel whose process dies while armed.
+  // The UI just reflects the reported state and toggles it over the protocol.
+  const killSwitch = state.kill_switch ?? false;
 
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -170,12 +166,9 @@ export function App() {
   );
 
   const handleToggleKill = useCallback(() => {
-    setKillSwitchState((prev) => {
-      const next = !prev;
-      persistKillSwitch(next);
-      return next;
-    });
-  }, []);
+    // Failures surface on the state/log channels the UI already renders.
+    void tenebra.setKillSwitch(!killSwitch).catch(() => {});
+  }, [tenebra, killSwitch]);
 
   const focusSearch = useCallback(() => {
     searchRef.current?.focus();
@@ -247,7 +240,7 @@ export function App() {
     <div className="app" data-conn={phase}>
       <TopBar activeProfile={metaProfile} />
 
-      {connected && killSwitch && KILL_SWITCH_WIRED && (
+      {connected && killSwitch && (
         <div className="kill-banner" role="status">
           ⚠ {t.bottom.killBanner}
         </div>
@@ -293,7 +286,6 @@ export function App() {
         onSetRouting={handleSetRouting}
         killSwitch={killSwitch}
         onToggleKillSwitch={handleToggleKill}
-        killSwitchDisabled={!KILL_SWITCH_WIRED}
         onLeakCheck={() => setOverlay("logs")}
         onSettings={() => setOverlay("settings")}
       />

--- a/ui-desktop/src/api/client.test.ts
+++ b/ui-desktop/src/api/client.test.ts
@@ -151,6 +151,20 @@ describe("api command wrappers", () => {
     });
   });
 
+  it("setKillSwitch forwards the flag and returns the State", async () => {
+    const armed: State = { state: "connected", kill_switch: true };
+    mockInvoke.mockResolvedValueOnce(armed);
+    await expect(api.setKillSwitch(true)).resolves.toEqual(armed);
+    expect(mockInvoke).toHaveBeenCalledWith("set_kill_switch", { on: true });
+  });
+
+  it("setTun forwards the stack and returns the State", async () => {
+    const swapped: State = { state: "idle", tun_stack: "gvisor" };
+    mockInvoke.mockResolvedValueOnce(swapped);
+    await expect(api.setTun("gvisor")).resolves.toEqual(swapped);
+    expect(mockInvoke).toHaveBeenCalledWith("set_tun", { stack: "gvisor" });
+  });
+
   it("leakCheck passes the LeakCheck verdict through", async () => {
     const leak: LeakCheck = {
       connected: false,

--- a/ui-desktop/src/api/client.ts
+++ b/ui-desktop/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   State,
   StateEvent,
   TrafficEvent,
+  TunStack,
 } from "./types";
 
 // Typed wrapper over the Tauri command surface. The Rust shell forwards every
@@ -90,6 +91,19 @@ export const api = {
   // The core normalizes them, so the returned State may reorder/lowercase them.
   setSplit(mode: SplitMode, apps: string[]): Promise<State> {
     return invoke<State>("set_split", { mode, apps });
+  },
+
+  // Arm/disarm the kill switch. The core persists the choice and, when a tunnel
+  // is live, re-applies it in place (a brief connecting→connected dip while
+  // sing-box hot-swaps on the same node — not a full reconnect).
+  setKillSwitch(on: boolean): Promise<State> {
+    return invoke<State>("set_kill_switch", { on });
+  },
+
+  // Switch the tun network stack. Same live re-apply semantics as the kill
+  // switch; when idle the choice applies on the next connect.
+  setTun(stack: TunStack): Promise<State> {
+    return invoke<State>("set_tun", { stack });
   },
 
   /**

--- a/ui-desktop/src/api/types.ts
+++ b/ui-desktop/src/api/types.ts
@@ -8,6 +8,13 @@ export type RoutingMode = "smart" | "global" | "direct";
 
 export type SplitMode = "off" | "exclude" | "include";
 
+/**
+ * The tun network stack sing-box runs: the kernel's own TCP/IP ("system",
+ * fastest, the default), a userspace stack ("gvisor", slower but immune to tun
+ * driver quirks), or TCP-on-system / UDP-on-gvisor ("mixed").
+ */
+export type TunStack = "system" | "gvisor" | "mixed";
+
 export type NodeProtocol =
   | "vless"
   | "hysteria2"
@@ -25,6 +32,10 @@ export interface State {
   split?: SplitMode;
   /** Normalized executable names the split applies to; omitted when off. */
   split_apps?: string[];
+  /** Whether the kill switch is armed; omitted (treated as off) when it isn't. */
+  kill_switch?: boolean;
+  /** The tun network stack the current or next tunnel uses. */
+  tun_stack?: TunStack;
   error?: string;
 }
 

--- a/ui-desktop/src/components/BottomBar.test.tsx
+++ b/ui-desktop/src/components/BottomBar.test.tsx
@@ -45,17 +45,25 @@ describe("BottomBar", () => {
   });
 
   describe("kill-switch", () => {
-    it("is disabled and never pressed while killSwitchDisabled", () => {
+    it("reflects the armed state", () => {
+      renderWithProviders(<BottomBar {...baseProps({ killSwitch: true })} />);
+
+      const button = screen.getByRole("button", { name: /kill-switch/ });
+      expect(button).toBeEnabled();
+      expect(button).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("requests a toggle on click", async () => {
+      const onToggleKillSwitch = vi.fn();
+      const user = userEvent.setup();
       renderWithProviders(
-        <BottomBar
-          {...baseProps({ killSwitch: true, killSwitchDisabled: true })}
-        />,
+        <BottomBar {...baseProps({ killSwitch: false, onToggleKillSwitch })} />,
       );
 
       const button = screen.getByRole("button", { name: /kill-switch/ });
-      expect(button).toBeDisabled();
-      // Even with killSwitch=true, a disabled switch must not present as active.
       expect(button).toHaveAttribute("aria-pressed", "false");
+      await user.click(button);
+      expect(onToggleKillSwitch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/ui-desktop/src/components/BottomBar.tsx
+++ b/ui-desktop/src/components/BottomBar.tsx
@@ -6,9 +6,6 @@ interface BottomBarProps {
   onSetRouting: (mode: RoutingMode) => void;
   killSwitch: boolean;
   onToggleKillSwitch: () => void;
-  /** True until the core actually enforces the kill-switch; renders the toggle
-   *  disabled so we never present a protection we don't deliver. */
-  killSwitchDisabled?: boolean;
   onLeakCheck: () => void;
   onSettings: () => void;
 }
@@ -29,7 +26,6 @@ export function BottomBar({
   onSetRouting,
   killSwitch,
   onToggleKillSwitch,
-  killSwitchDisabled = false,
   onLeakCheck,
   onSettings,
 }: BottomBarProps) {
@@ -54,14 +50,13 @@ export function BottomBar({
         </div>
         <button
           type="button"
-          className={`toggle${killSwitch && !killSwitchDisabled ? " on" : ""}`}
-          aria-pressed={killSwitch && !killSwitchDisabled}
-          disabled={killSwitchDisabled}
-          title={killSwitchDisabled ? t.bottom.killSwitchPending : undefined}
+          className={`toggle${killSwitch ? " on" : ""}`}
+          aria-pressed={killSwitch}
+          title={t.bottom.killSwitchHint}
           onClick={onToggleKillSwitch}
         >
           <span className="box" aria-hidden="true">
-            {killSwitch && !killSwitchDisabled ? "▣" : "▢"}
+            {killSwitch ? "▣" : "▢"}
           </span>
           {t.bottom.killSwitch}
         </button>

--- a/ui-desktop/src/i18n/strings.ts
+++ b/ui-desktop/src/i18n/strings.ts
@@ -66,8 +66,8 @@ export interface Strings {
     routing: string;
     killSwitch: string;
     killBanner: string;
-    /** Tooltip while the kill-switch is present but not yet core-enforced. */
-    killSwitchPending: string;
+    /** Tooltip explaining what arming actually does (and costs). */
+    killSwitchHint: string;
     leakCheck: string;
     settings: string;
   };
@@ -165,6 +165,14 @@ export interface Strings {
     splitAddPlaceholder: string;
     splitAdd: string;
     splitRemove: string;
+    tunnel: string;
+    tunnelHint: string;
+    stackSystem: string;
+    stackSystemHint: string;
+    stackGvisor: string;
+    stackGvisorHint: string;
+    stackMixed: string;
+    stackMixedHint: string;
     appearance: string;
     theme: string;
     themeDark: string;
@@ -297,7 +305,8 @@ const en: Strings = {
     routing: "Routing",
     killSwitch: "kill-switch",
     killBanner: "KILL-SWITCH ARMED · traffic blocked if the tunnel drops",
-    killSwitchPending: "Kill-switch isn't wired to the core yet",
+    killSwitchHint:
+      "Block traffic that tries to bypass the tunnel; if the tunnel dies, restart it. Applies live; connects get rougher while armed.",
     leakCheck: "leak-check",
     settings: "settings",
   },
@@ -386,6 +395,15 @@ const en: Strings = {
     splitAddPlaceholder: "chrome.exe",
     splitAdd: "Add",
     splitRemove: "Remove",
+    tunnel: "Tunnel",
+    tunnelHint:
+      "Which network stack drives the TUN device. Changing it while connected re-applies the tunnel in place (a brief reconnect on the same node).",
+    stackSystem: "System",
+    stackSystemHint: "The kernel's own TCP/IP. Fastest; the default.",
+    stackGvisor: "gVisor",
+    stackGvisorHint: "Userspace stack. Slower, but immune to TUN driver quirks.",
+    stackMixed: "Mixed",
+    stackMixedHint: "TCP on the system stack, UDP on gVisor.",
     appearance: "Appearance",
     theme: "Theme",
     themeDark: "Dark",
@@ -504,7 +522,8 @@ const ru: Strings = {
     routing: "Маршрут",
     killSwitch: "kill-switch",
     killBanner: "KILL-SWITCH ВКЛ · трафик блокируется при обрыве туннеля",
-    killSwitchPending: "Kill-switch ещё не подключён к ядру",
+    killSwitchHint:
+      "Блокировать трафик в обход туннеля; при падении туннеля — перезапустить его. Применяется сразу; коннект с ним грубее.",
     leakCheck: "проверка",
     settings: "настройки",
   },
@@ -593,6 +612,15 @@ const ru: Strings = {
     splitAddPlaceholder: "chrome.exe",
     splitAdd: "Добавить",
     splitRemove: "Удалить",
+    tunnel: "Туннель",
+    tunnelHint:
+      "Какой сетевой стек обслуживает TUN-устройство. Смена при живом туннеле применяется на месте (короткий реконнект на тот же узел).",
+    stackSystem: "Системный",
+    stackSystemHint: "TCP/IP ядра ОС. Самый быстрый; по умолчанию.",
+    stackGvisor: "gVisor",
+    stackGvisorHint: "Стек в user space. Медленнее, но не зависит от капризов TUN-драйвера.",
+    stackMixed: "Смешанный",
+    stackMixedHint: "TCP через системный стек, UDP через gVisor.",
     appearance: "Оформление",
     theme: "Тема",
     themeDark: "Тёмная",

--- a/ui-desktop/src/lib/settings.ts
+++ b/ui-desktop/src/lib/settings.ts
@@ -5,7 +5,6 @@
 
 const AUTOCONNECT_KEY = "tenebra.autoconnect";
 const LAST_PROFILE_KEY = "tenebra.lastProfile";
-const KILLSWITCH_KEY = "tenebra.killSwitch";
 const AUTO_FASTEST_KEY = "tenebra.autoFastest";
 
 /** Whether "connect on launch" is enabled. Off unless explicitly turned on. */
@@ -27,18 +26,9 @@ export function setLastProfileId(id: string): void {
   localStorage.setItem(LAST_PROFILE_KEY, id);
 }
 
-/**
- * Whether the kill-switch (drop proxied traffic instead of leaking when the
- * tunnel drops) is armed. Persisted here so the choice survives restarts and so
- * the connect flow can pass it to the core. Off unless explicitly armed.
- */
-export function getKillSwitch(): boolean {
-  return localStorage.getItem(KILLSWITCH_KEY) === "1";
-}
-
-export function setKillSwitch(on: boolean): void {
-  localStorage.setItem(KILLSWITCH_KEY, on ? "1" : "0");
-}
+// The kill switch used to be a renderer-side flag here ("tenebra.killSwitch");
+// it is now core-owned: the daemon persists it in its settings.json, arms it in
+// the tunnel config, and reports it back through State.kill_switch.
 
 /**
  * Whether "auto-select fastest node" is enabled. When on, a connect without an

--- a/ui-desktop/src/screens/SettingsScreen.test.tsx
+++ b/ui-desktop/src/screens/SettingsScreen.test.tsx
@@ -148,6 +148,58 @@ describe("SettingsScreen", () => {
     });
   });
 
+  describe("tunnel stack", () => {
+    it("marks the reported stack as checked, defaulting to system", () => {
+      const tenebra = makeTenebra({ state: { state: "idle" } as State });
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      expect(screen.getByRole("radio", { name: /^System/ })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      expect(screen.getByRole("radio", { name: /^gVisor/ })).toHaveAttribute(
+        "aria-checked",
+        "false",
+      );
+    });
+
+    it("reflects a non-default stack from the core state", () => {
+      const tenebra = makeTenebra({
+        state: { state: "idle", tun_stack: "mixed" } as State,
+      });
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      expect(screen.getByRole("radio", { name: /^Mixed/ })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+    });
+
+    it("requests the new stack on click and skips a no-op", async () => {
+      const tenebra = makeTenebra({ state: { state: "idle" } as State });
+      const user = userEvent.setup();
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      await user.click(screen.getByRole("radio", { name: /^gVisor/ }));
+      expect(tenebra.setTun).toHaveBeenCalledWith("gvisor");
+
+      // Clicking the already-active stack must not re-apply (a live tunnel
+      // would be pointlessly hot-swapped).
+      await user.click(screen.getByRole("radio", { name: /^System/ }));
+      expect(tenebra.setTun).toHaveBeenCalledTimes(1);
+    });
+
+    it("moves to the next stack on ArrowDown", () => {
+      const tenebra = makeTenebra({ state: { state: "idle" } as State });
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      fireEvent.keyDown(screen.getByRole("radio", { name: /^System/ }), {
+        key: "ArrowDown",
+      });
+      expect(tenebra.setTun).toHaveBeenCalledWith("gvisor");
+    });
+  });
+
   describe("startup", () => {
     // The switch's accessible name is its own text ("ON"/"OFF"), not the sibling
     // label, so locate the row by its label text and grab the switch within it.

--- a/ui-desktop/src/screens/SettingsScreen.test.tsx
+++ b/ui-desktop/src/screens/SettingsScreen.test.tsx
@@ -83,6 +83,38 @@ describe("SettingsScreen", () => {
       // smart is index 0; ArrowDown advances to global.
       expect(tenebra.setRouting).toHaveBeenCalledWith("global");
     });
+
+    it("carries focus with selection so repeated ArrowDown reaches every mode", async () => {
+      const tenebra = makeTenebra({
+        state: { state: "idle", routing: "smart" } as State,
+      });
+      const user = userEvent.setup();
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      const smart = screen.getByRole("radio", { name: /Smart/ });
+      const global = screen.getByRole("radio", { name: /Global/ });
+      const direct = screen.getByRole("radio", { name: /Direct/ });
+
+      // Start where the roving tabIndex parks the caret: on the checked option.
+      smart.focus();
+      expect(smart).toHaveFocus();
+
+      // Each ArrowDown must move focus AND selection onward. The focus move is
+      // what re-anchors the index; without it the second press would recompute
+      // from smart and stall on global (the reported defect).
+      await user.keyboard("{ArrowDown}");
+      expect(global).toHaveFocus();
+      expect(tenebra.setRouting).toHaveBeenLastCalledWith("global");
+
+      await user.keyboard("{ArrowDown}");
+      expect(direct).toHaveFocus();
+      expect(tenebra.setRouting).toHaveBeenLastCalledWith("direct");
+
+      // A third press wraps around to the first option.
+      await user.keyboard("{ArrowDown}");
+      expect(smart).toHaveFocus();
+      expect(tenebra.setRouting).toHaveBeenLastCalledWith("smart");
+    });
   });
 
   describe("split tunnelling", () => {
@@ -146,6 +178,33 @@ describe("SettingsScreen", () => {
         "firefox.exe",
       ]);
     });
+
+    it("carries focus with selection so repeated ArrowDown reaches every mode", async () => {
+      const tenebra = makeTenebra({ state: { state: "idle" } as State });
+      const user = userEvent.setup();
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      const off = screen.getByRole("radio", { name: /^Off/ });
+      const exclude = screen.getByRole("radio", { name: /Exclude apps/ });
+      const include = screen.getByRole("radio", { name: /Only these apps/ });
+
+      // off is index 0 (the default split mode).
+      off.focus();
+      expect(off).toHaveFocus();
+
+      await user.keyboard("{ArrowDown}");
+      expect(exclude).toHaveFocus();
+      expect(tenebra.setSplit).toHaveBeenLastCalledWith("exclude", []);
+
+      await user.keyboard("{ArrowDown}");
+      expect(include).toHaveFocus();
+      expect(tenebra.setSplit).toHaveBeenLastCalledWith("include", []);
+
+      // Wraps back to off; re-selecting the already-active mode is a no-op in
+      // the core, but focus must still travel so the group stays navigable.
+      await user.keyboard("{ArrowDown}");
+      expect(off).toHaveFocus();
+    });
   });
 
   describe("tunnel stack", () => {
@@ -197,6 +256,33 @@ describe("SettingsScreen", () => {
         key: "ArrowDown",
       });
       expect(tenebra.setTun).toHaveBeenCalledWith("gvisor");
+    });
+
+    it("carries focus with selection so repeated ArrowDown reaches every stack", async () => {
+      const tenebra = makeTenebra({ state: { state: "idle" } as State });
+      const user = userEvent.setup();
+      renderWithProviders(<SettingsScreen tenebra={tenebra} />);
+
+      const system = screen.getByRole("radio", { name: /^System/ });
+      const gvisor = screen.getByRole("radio", { name: /^gVisor/ });
+      const mixed = screen.getByRole("radio", { name: /^Mixed/ });
+
+      // system is index 0 (the default stack).
+      system.focus();
+      expect(system).toHaveFocus();
+
+      await user.keyboard("{ArrowDown}");
+      expect(gvisor).toHaveFocus();
+      expect(tenebra.setTun).toHaveBeenLastCalledWith("gvisor");
+
+      await user.keyboard("{ArrowDown}");
+      expect(mixed).toHaveFocus();
+      expect(tenebra.setTun).toHaveBeenLastCalledWith("mixed");
+
+      // Wraps back to system; re-selecting the active stack is a no-op in the
+      // core, but focus must still travel so the group stays navigable.
+      await user.keyboard("{ArrowDown}");
+      expect(system).toHaveFocus();
     });
   });
 

--- a/ui-desktop/src/screens/SettingsScreen.tsx
+++ b/ui-desktop/src/screens/SettingsScreen.tsx
@@ -3,7 +3,7 @@ import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { getVersion } from "@tauri-apps/api/app";
 import type { Update } from "@tauri-apps/plugin-updater";
 
-import type { RoutingMode, SplitMode } from "../api";
+import type { RoutingMode, SplitMode, TunStack } from "../api";
 import type { Tenebra } from "../state/useTenebra";
 import { useI18n } from "../i18n/I18nContext";
 import { useTheme } from "../theme/ThemeContext";
@@ -230,6 +230,34 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
     }
   }
 
+  // The tun network stack. Core-owned like routing: the daemon validates,
+  // persists, and — when a tunnel is live — re-applies it in place, so the UI
+  // just reflects tenebra.state and requests changes.
+  const tunStack = tenebra.state.tun_stack ?? "system";
+
+  const stackOptions: { stack: TunStack; label: string; hint: string }[] = [
+    { stack: "system", label: t.settings.stackSystem, hint: t.settings.stackSystemHint },
+    { stack: "gvisor", label: t.settings.stackGvisor, hint: t.settings.stackGvisorHint },
+    { stack: "mixed", label: t.settings.stackMixed, hint: t.settings.stackMixedHint },
+  ];
+
+  function chooseStack(stack: TunStack) {
+    if (stack === tunStack) {
+      return;
+    }
+    void tenebra.setTun(stack);
+  }
+
+  function onStackKey(e: KeyboardEvent, index: number) {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") {
+      return;
+    }
+    e.preventDefault();
+    const delta = e.key === "ArrowDown" ? 1 : -1;
+    const next = stackOptions[(index + delta + stackOptions.length) % stackOptions.length];
+    chooseStack(next.stack);
+  }
+
   const themeOptions: { value: "dark" | "light"; label: string }[] = [
     { value: "dark", label: t.settings.themeDark },
     { value: "light", label: t.settings.themeLight },
@@ -352,6 +380,36 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
             )}
           </div>
         )}
+      </section>
+
+      <section className="set-section">
+        <div className="set-section-head">
+          <h2 className="set-eyebrow">{t.settings.tunnel}</h2>
+          <p className="set-sub">{t.settings.tunnelHint}</p>
+        </div>
+        <div className="set-options" role="radiogroup" aria-label={t.settings.tunnel}>
+          {stackOptions.map((opt, index) => {
+            const checked = tunStack === opt.stack;
+            return (
+              <button
+                key={opt.stack}
+                type="button"
+                role="radio"
+                aria-checked={checked}
+                tabIndex={checked ? 0 : -1}
+                className={`set-option${checked ? " is-checked" : ""}`}
+                onClick={() => chooseStack(opt.stack)}
+                onKeyDown={(e) => onStackKey(e, index)}
+              >
+                <span className="set-mark" aria-hidden="true">{checked ? "▣" : "▢"}</span>
+                <span className="set-option-text">
+                  <span className="set-option-label">{opt.label}</span>
+                  <span className="set-option-hint">{opt.hint}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </section>
 
       <section className="set-section">

--- a/ui-desktop/src/screens/SettingsScreen.tsx
+++ b/ui-desktop/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { getVersion } from "@tauri-apps/api/app";
 import type { Update } from "@tauri-apps/plugin-updater";
@@ -160,14 +160,22 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
     { mode: "direct", label: t.settings.routingDirect, hint: t.settings.routingDirectHint },
   ];
 
+  // One ref slot per radio button so an arrow key can move DOM focus onto the
+  // newly selected option. Focus has to travel with the selection: the roving
+  // tabIndex re-anchors on whatever holds focus, so without this the next key
+  // press would recompute from the original (now stale) index and stall.
+  const routingRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
   function onRoutingKey(e: KeyboardEvent, index: number) {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") {
       return;
     }
     e.preventDefault();
     const delta = e.key === "ArrowDown" ? 1 : -1;
-    const next = routingOptions[(index + delta + routingOptions.length) % routingOptions.length];
-    void tenebra.setRouting(next.mode);
+    const nextIndex =
+      (index + delta + routingOptions.length) % routingOptions.length;
+    void tenebra.setRouting(routingOptions[nextIndex].mode);
+    routingRefs.current[nextIndex]?.focus();
   }
 
   // Split tunnelling. The core owns the canonical list (it normalizes names), so
@@ -190,14 +198,19 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
     void tenebra.setSplit(mode, splitApps);
   }
 
+  // See routingRefs: arrow keys move focus along with the selection here too.
+  const splitRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
   function onSplitKey(e: KeyboardEvent, index: number) {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") {
       return;
     }
     e.preventDefault();
     const delta = e.key === "ArrowDown" ? 1 : -1;
-    const next = splitOptions[(index + delta + splitOptions.length) % splitOptions.length];
-    chooseSplitMode(next.mode);
+    const nextIndex =
+      (index + delta + splitOptions.length) % splitOptions.length;
+    chooseSplitMode(splitOptions[nextIndex].mode);
+    splitRefs.current[nextIndex]?.focus();
   }
 
   // Normalize the draft the same way the core does for the dedupe check, so the
@@ -248,14 +261,19 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
     void tenebra.setTun(stack);
   }
 
+  // See routingRefs: arrow keys move focus along with the selection here too.
+  const stackRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
   function onStackKey(e: KeyboardEvent, index: number) {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") {
       return;
     }
     e.preventDefault();
     const delta = e.key === "ArrowDown" ? 1 : -1;
-    const next = stackOptions[(index + delta + stackOptions.length) % stackOptions.length];
-    chooseStack(next.stack);
+    const nextIndex =
+      (index + delta + stackOptions.length) % stackOptions.length;
+    chooseStack(stackOptions[nextIndex].stack);
+    stackRefs.current[nextIndex]?.focus();
   }
 
   const themeOptions: { value: "dark" | "light"; label: string }[] = [
@@ -282,6 +300,9 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
             return (
               <button
                 key={opt.mode}
+                ref={(el) => {
+                  routingRefs.current[index] = el;
+                }}
                 type="button"
                 role="radio"
                 aria-checked={checked}
@@ -313,6 +334,9 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
             return (
               <button
                 key={opt.mode}
+                ref={(el) => {
+                  splitRefs.current[index] = el;
+                }}
                 type="button"
                 role="radio"
                 aria-checked={checked}
@@ -393,6 +417,9 @@ export function SettingsScreen({ tenebra }: SettingsScreenProps) {
             return (
               <button
                 key={opt.stack}
+                ref={(el) => {
+                  stackRefs.current[index] = el;
+                }}
                 type="button"
                 role="radio"
                 aria-checked={checked}

--- a/ui-desktop/src/state/useTenebra.test.ts
+++ b/ui-desktop/src/state/useTenebra.test.ts
@@ -29,6 +29,8 @@ const mockApi = vi.hoisted(() => ({
   disconnect: vi.fn(),
   setRouting: vi.fn(),
   setSplit: vi.fn(),
+  setKillSwitch: vi.fn(),
+  setTun: vi.fn(),
 }));
 
 vi.mock("../api", async (orig) => {
@@ -263,6 +265,32 @@ describe("actions", () => {
     expect(mockApi.setSplit).toHaveBeenCalledWith("exclude", ["chrome.exe"]);
     expect(result.current.state.split).toBe("exclude");
     expect(result.current.state.split_apps).toEqual(["chrome.exe"]);
+  });
+
+  it("setKillSwitch calls api.setKillSwitch and applies the returned state", async () => {
+    const next: State = { state: "idle", kill_switch: true };
+    mockApi.setKillSwitch.mockResolvedValue(next);
+    const { result } = await mountReady();
+
+    await act(async () => {
+      await result.current.setKillSwitch(true);
+    });
+
+    expect(mockApi.setKillSwitch).toHaveBeenCalledWith(true);
+    expect(result.current.state.kill_switch).toBe(true);
+  });
+
+  it("setTun calls api.setTun and applies the returned state", async () => {
+    const next: State = { state: "idle", tun_stack: "gvisor" };
+    mockApi.setTun.mockResolvedValue(next);
+    const { result } = await mountReady();
+
+    await act(async () => {
+      await result.current.setTun("gvisor");
+    });
+
+    expect(mockApi.setTun).toHaveBeenCalledWith("gvisor");
+    expect(result.current.state.tun_stack).toBe("gvisor");
   });
 });
 

--- a/ui-desktop/src/state/useTenebra.ts
+++ b/ui-desktop/src/state/useTenebra.ts
@@ -14,6 +14,7 @@ import {
   type SplitMode,
   type State,
   type TrafficEvent,
+  type TunStack,
 } from "../api";
 
 export interface LogLine {
@@ -47,6 +48,8 @@ export interface Tenebra {
   disconnect: () => Promise<void>;
   setRouting: (mode: RoutingMode) => Promise<void>;
   setSplit: (mode: SplitMode, apps: string[]) => Promise<void>;
+  setKillSwitch: (on: boolean) => Promise<void>;
+  setTun: (stack: TunStack) => Promise<void>;
   refreshProfiles: () => Promise<void>;
   clearLogs: () => void;
 }
@@ -174,6 +177,16 @@ export function useTenebra(): Tenebra {
     setState(next);
   }, []);
 
+  const setKillSwitch = useCallback(async (on: boolean) => {
+    const next = await api.setKillSwitch(on);
+    setState(next);
+  }, []);
+
+  const setTun = useCallback(async (stack: TunStack) => {
+    const next = await api.setTun(stack);
+    setState(next);
+  }, []);
+
   const clearLogs = useCallback(() => setLogs([]), []);
 
   return {
@@ -186,6 +199,8 @@ export function useTenebra(): Tenebra {
     disconnect,
     setRouting,
     setSplit,
+    setKillSwitch,
+    setTun,
     refreshProfiles,
     clearLogs,
   };

--- a/ui-desktop/src/test/fixtures.ts
+++ b/ui-desktop/src/test/fixtures.ts
@@ -47,6 +47,8 @@ export function makeTenebra(overrides: Partial<Tenebra> = {}): Tenebra {
     disconnect: vi.fn().mockResolvedValue(undefined),
     setRouting: vi.fn().mockResolvedValue(undefined),
     setSplit: vi.fn().mockResolvedValue(undefined),
+    setKillSwitch: vi.fn().mockResolvedValue(undefined),
+    setTun: vi.fn().mockResolvedValue(undefined),
     refreshProfiles: vi.fn().mockResolvedValue(undefined),
     clearLogs: vi.fn(),
     ...overrides,


### PR DESCRIPTION
Wires the kill switch end to end and makes the TUN stack selectable (system / gvisor / mixed).

- Core: set_kill_switch and set_tun commands, state reporting, settings persistence, live re-apply via hot swap on the current node, strict_route plus automatic relaunch of a dead sing-box process (budget of 5, reset on explicit connect/disconnect).
- Shell: backend trait plumbing for both commands with wire tests.
- UI: kill switch toggle un-gated, new Tunnel section in Settings with stack selection.

Known limitation is documented in docs/control-protocol.md: between process death and relaunch the OS routes around the tunnel, so the kill switch is best-effort without a WFP hold.