### PR TITLE
Add winget publishing workflow and install docs

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,57 @@
+name: Winget
+
+# Publishes stable releases to the Windows Package Manager community repo
+# (microsoft/winget-pkgs): winget-releaser drives komac, which reads the
+# GitHub release, bumps the manifests and opens the winget-pkgs PR from the
+# Divaaaan fork. The `released` event never fires for pre-releases, so
+# android-alpha tags stay out of winget; workflow_dispatch covers re-runs or
+# publishing a release that predates this workflow.
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.4.5)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  # secrets.* cannot be read in a job-level `if`, so a gate job exposes
+  # "is the token configured" as an output (same pattern as the Android
+  # release gate). Without WINGET_TOKEN the publish job skips with a notice;
+  # add the secret and the workflow arms itself on the next release.
+  winget-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [ -n "$WINGET_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::WINGET_TOKEN is not configured; skipping the winget publish."
+          fi
+
+  publish:
+    needs: winget-gate
+    if: needs.winget-gate.outputs.enabled == 'true'
+    # winget-releaser documents windows-latest; this job fires once per
+    # release and is painful to debug, so stay on the beaten path.
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Divaaaan.Tenebra
+          # Only the Windows NSIS installer — keeps the macOS dmg/tar.gz and
+          # any future artifacts out of the winget manifest.
+          installers-regex: '_x64-setup\.exe$'
+          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ The kill-switch (drop proxied traffic instead of leaking when the tunnel drops) 
 UI toggle — best-effort by design, with the exact guarantee described in the
 [changelog](CHANGELOG.md); LAN bypass is a core routing option.
 
+## Installing
+
+**Windows** — from the [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/):
+
+```powershell
+winget install Divaaaan.Tenebra
+```
+
+or grab `Tenebra_x.y.z_x64-setup.exe` from the
+[latest release](https://github.com/Divaaaan/tenebra/releases/latest). Either
+way the installer sets up the background service and the in-app updater keeps
+everything current.
+
+**macOS** — download the universal DMG from the
+[latest release](https://github.com/Divaaaan/tenebra/releases/latest), then
+read the [macOS note](#macos-note--read-before-downloading-the-dmg) first —
+the build currently needs a hand-installed root daemon.
+
 ## Getting a server
 
 Tenebra is a **client** — it ships no servers and hard-codes nothing. You bring


### PR DESCRIPTION
Tenebra landed in the Windows Package Manager community repo (`Divaaaan.Tenebra`, winget-pkgs #400325). This wires up automation so it stays current:

- `.github/workflows/winget.yml` — on every stable release, winget-releaser/komac reads the release, bumps the manifests and opens the winget-pkgs PR from the existing fork. A gate job skips the publish with a notice until the `WINGET_TOKEN` secret (classic PAT, `public_repo`) is configured, so release runs never go red over a missing secret. The `released` event keeps pre-releases (android alphas) out of winget; `workflow_dispatch` covers manual re-runs.
- README — new **Installing** section with the `winget install Divaaaan.Tenebra` one-liner and the macOS pointer.

The 0.3.0 → 0.4.5 manifest catch-up went separately as microsoft/winget-pkgs#407736 (this workflow takes over from the next release).